### PR TITLE
add persistent volume to crowdsec chart

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -48,10 +48,14 @@ helm delete crowdsec -n crowdsec
 | lapi.dashboard.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy |
 | lapi.dashboard.image.tag | string | `"v0.41.5"` | docker image tag |
 | lapi.dashboard.assetURL | string | `"https://crowdsec-statics-assets.s3-eu-west-1.amazonaws.com/metabase_sqlite.zip"` | Metabase SQLite static DB containing Dashboards |
-| lapi.persistentVolume.enabled | bool | `false` | Defines if persistent volume should be created |
-| lapi.persistentVolume.accessModes | list | `[ReadWriteOnce]` | Defines the access modes for the storage |
-| lapi.persistentVolume.storageClassName | string | `""` | The storage class to use |
-| lapi.persistentVolume.size | size | `1Gi` | Defines the storage size |
+| lapi.persistentVolume.data.enabled | bool | `true` | Defines if persistent volume for the database should be created|
+| lapi.persistentVolume.data.accessModes | list | `[ReadWriteOnce]` | Defines the access modes for the storage |
+| lapi.persistentVolume.data.storageClassName | string | `""` | The storage class to use |
+| lapi.persistentVolume.data.size | size | `1Gi` | Defines the storage size |
+| lapi.persistentVolume.config.enabled | bool | `true` | Defines if persistent volume for the configuration storage should be created (e.g. online api credentials)|
+| lapi.persistentVolume.config.accessModes | list | `[ReadWriteOnce]` | Defines the access modes for the storage |
+| lapi.persistentVolume.config.storageClassName | string | `""` | The storage class to use |
+| lapi.persistentVolume.config.size | size | `100Mi` | Defines the storage size |
 | lapi.resources.limits.memory | string | `"100Mi"` |  |
 | lapi.resources.requests.cpu | string | `"150m"` |  |
 | lapi.resources.requests.memory | string | `"100Mi"` |  |

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -48,6 +48,10 @@ helm delete crowdsec -n crowdsec
 | lapi.dashboard.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy |
 | lapi.dashboard.image.tag | string | `"v0.41.5"` | docker image tag |
 | lapi.dashboard.assetURL | string | `"https://crowdsec-statics-assets.s3-eu-west-1.amazonaws.com/metabase_sqlite.zip"` | Metabase SQLite static DB containing Dashboards |
+| lapi.persistentVolume.enabled | bool | `false` | Defines if persistent volume should be created |
+| lapi.persistentVolume.accessModes | list | `[ReadWriteOnce]` | Defines the access modes for the storage |
+| lapi.persistentVolume.storageClassName | string | `""` | The storage class to use |
+| lapi.persistentVolume.size | size | `1Gi` | Defines the storage size |
 | lapi.resources.limits.memory | string | `"100Mi"` |  |
 | lapi.resources.requests.cpu | string | `"150m"` |  |
 | lapi.resources.requests.memory | string | `"100Mi"` |  |

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -57,10 +57,18 @@ spec:
           - name: lapi-prometheus
             containerPort: 6060
             protocol: TCP
-      {{ if .Values.lapi.dashboard.enabled }}
+        {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) }}
         volumeMounts:
+          {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.dashboard.enabled) }}
           - name: crowdsec-db
             mountPath: /var/lib/crowdsec/data
+          {{- end }}
+          {{- if .Values.lapi.persistentVolume.config.enabled }}
+          - name: crowdsec-config
+            mountPath: /etc/crowdsec
+          {{- end }}
+        {{- end }}
+      {{- if .Values.lapi.dashboard.enabled }}
       - name: dashboard
         image: "{{ .Values.lapi.dashboard.image.repository | default "metabase/metabase" }}:{{ .Values.lapi.dashboard.image.tag | default "latest" }}"
         imagePullPolicy: {{ .Values.lapi.dashboard.image.pullPolicy }}
@@ -72,17 +80,25 @@ spec:
         env:
           - name: MB_DB_FILE
             value: /metabase-data/metabase.db
-      {{ end }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
-      {{ if .Values.lapi.dashboard.enabled }}
+      {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) }}
       volumes:
+      {{- if .Values.lapi.dashboard.enabled }}
       - name: shared-data
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.lapi.persistentVolume.data.enabled }}
       - name: crowdsec-db
-        {{- if .Values.lapi.persistentVolume.enabled }}
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-db-pvc
-        {{- else }}
+      {{- else if .Values.lapi.dashboard.enabled }}
+      - name: crowdsec-db
         emptyDir: {}
-        {{- end -}}
-      {{ end }}
+      {{- end }}
+      {{- if .Values.lapi.persistentVolume.config.enabled }}
+      - name: crowdsec-config
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-config-pvc
+      {{- end }}
+      {{- end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -79,5 +79,10 @@ spec:
       - name: shared-data
         emptyDir: {}
       - name: crowdsec-db
+        {{- if .Values.lapi.persistentVolume.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-db-pvc
+        {{- else }}
         emptyDir: {}
+        {{- end -}}
       {{ end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -57,6 +57,9 @@ spec:
           - name: lapi-prometheus
             containerPort: 6060
             protocol: TCP
+        {{- if .Values.lapi.persistentVolume.config.enabled }}
+        command: ['sh', '-c', 'mv -n /etc/crowdsec/* /etc/crowdsec_data/ && rm -rf /etc/crowdsec && ln -s /etc/crowdsec_data /etc/crowdsec && ./docker_start.sh']
+        {{- end }}
         {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) }}
         volumeMounts:
           {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.dashboard.enabled) }}
@@ -65,7 +68,7 @@ spec:
           {{- end }}
           {{- if .Values.lapi.persistentVolume.config.enabled }}
           - name: crowdsec-config
-            mountPath: /etc/crowdsec
+            mountPath: /etc/crowdsec_data
           {{- end }}
         {{- end }}
       {{- if .Values.lapi.dashboard.enabled }}

--- a/charts/crowdsec/templates/lapi-persistentVolume.yaml
+++ b/charts/crowdsec/templates/lapi-persistentVolume.yaml
@@ -14,7 +14,13 @@ metadata:
 spec:
   accessModes:
 {{ toYaml .Values.lapi.persistentVolume.data.accessModes | indent 4 }}
-  storageClassName: {{ .Values.lapi.persistentVolume.data.storageClassName }}
+{{- if .Values.lapi.persistentVolume.data.storageClassName }}
+{{- if (eq "-" .Values.lapi.persistentVolume.data.storageClassName) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.lapi.persistentVolume.data.storageClassName }}"
+{{- end }}
+{{- end }}
   resources:
     requests:
       storage: "{{ .Values.lapi.persistentVolume.data.size }}"
@@ -36,7 +42,13 @@ metadata:
 spec:
   accessModes:
 {{ toYaml .Values.lapi.persistentVolume.config.accessModes | indent 4 }}
-  storageClassName: {{ .Values.lapi.persistentVolume.config.storageClassName }}
+{{- if .Values.lapi.persistentVolume.config.storageClassName }}
+{{- if (eq "-" .Values.lapi.persistentVolume.config.storageClassName) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.lapi.persistentVolume.config.storageClassName }}"
+{{- end }}
+{{- end }}
   resources:
     requests:
       storage: "{{ .Values.lapi.persistentVolume.config.size }}"

--- a/charts/crowdsec/templates/lapi-persistentVolume.yaml
+++ b/charts/crowdsec/templates/lapi-persistentVolume.yaml
@@ -1,11 +1,11 @@
-{{ if .Values.lapi.persistentVolume.enabled }}
+{{ if .Values.lapi.persistentVolume.data.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-db-pvc
-  {{- if .Values.lapi.persistentVolume.annotations }}
+  {{- if .Values.lapi.persistentVolume.data.annotations }}
   annotations:
-{{ toYaml .Values.lapi.persistentVolume.annotations | indent 4 }}
+{{ toYaml .Values.lapi.persistentVolume.data.annotations | indent 4 }}
   {{- end }}
   labels:
     k8s-app: {{ .Release.Name }}
@@ -13,9 +13,31 @@ metadata:
     version: v1
 spec:
   accessModes:
-{{ toYaml .Values.lapi.persistentVolume.accessModes | indent 4 }}
-  storageClassName: {{ .Values.lapi.persistentVolume.storageClassName }}
+{{ toYaml .Values.lapi.persistentVolume.data.accessModes | indent 4 }}
+  storageClassName: {{ .Values.lapi.persistentVolume.data.storageClassName }}
   resources:
     requests:
-      storage: "{{ .Values.lapi.persistentVolume.size }}"
+      storage: "{{ .Values.lapi.persistentVolume.data.size }}"
+{{ end }}
+---
+{{ if .Values.lapi.persistentVolume.config.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-config-pvc
+  {{- if .Values.lapi.persistentVolume.config.annotations }}
+  annotations:
+{{ toYaml .Values.lapi.persistentVolume.config.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    k8s-app: {{ .Release.Name }}
+    type: lapi
+    version: v1
+spec:
+  accessModes:
+{{ toYaml .Values.lapi.persistentVolume.config.accessModes | indent 4 }}
+  storageClassName: {{ .Values.lapi.persistentVolume.config.storageClassName }}
+  resources:
+    requests:
+      storage: "{{ .Values.lapi.persistentVolume.config.size }}"
 {{ end }}

--- a/charts/crowdsec/templates/lapi-persistentVolume.yaml
+++ b/charts/crowdsec/templates/lapi-persistentVolume.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.lapi.persistentVolume.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-db-pvc
+  {{- if .Values.lapi.persistentVolume.annotations }}
+  annotations:
+{{ toYaml .Values.lapi.persistentVolume.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    k8s-app: {{ .Release.Name }}
+    type: lapi
+    version: v1
+spec:
+  accessModes:
+{{ toYaml .Values.lapi.persistentVolume.accessModes | indent 4 }}
+  storageClassName: {{ .Values.lapi.persistentVolume.storageClassName }}
+  resources:
+    requests:
+      storage: "{{ .Values.lapi.persistentVolume.size }}"
+{{ end }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -43,13 +43,22 @@ lapi:
     requests:
       cpu: 150m
       memory: 100Mi
-  # -- Enable persistent volume for data folder
+  # -- Enable persistent volumes
   persistentVolume:
-    enabled: true
-    accessModes: 
-      - ReadWriteOnce
-    storageClassName: ""
-    size: 1Gi
+    # -- Persistent volume for data folder. Stores e.g. registered bouncer api keys
+    data:
+      enabled: true
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: ""
+      size: 1Gi
+    # -- Persistent volume for config folder. Stores e.g. online api credentials
+    config:
+      enabled: true
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: ""
+      size: 100Mi
 
 # agent will deploy pod on every node as daemonSet to read wanted pods logs
 agent:

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -43,6 +43,13 @@ lapi:
     requests:
       cpu: 150m
       memory: 100Mi
+  # -- Enable persistent volume for data folder
+  persistentVolume:
+    enabled: true
+    accessModes: 
+      - ReadWriteOnce
+    storageClassName: ""
+    size: 1Gi
 
 # agent will deploy pod on every node as daemonSet to read wanted pods logs
 agent:


### PR DESCRIPTION
This adds a persistent volume to the crowdsec helm chart so the database can be persistent and will survive a pod update. Currently if you destroy the lapi pod, the list of known bouncers is destroyed and you need to register them again.