### PR TITLE
Prevent secret regeneration with helm update

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/templates/_helpers.tpl
+++ b/charts/crowdsec/templates/_helpers.tpl
@@ -4,6 +4,9 @@ Generate username if not specified in values
 {{ define "agent.username" }}
 {{- if .Values.secrets.username }}
   {{- .Values.secrets.username -}}
+{{- else if (lookup "v1" "Secret" .Release.Namespace "agent-credentials").data }}
+  {{- $obj := (lookup "v1" "Secret" .Release.Namespace "agent-credentials").data -}}
+  {{- index $obj "username" | b64dec -}}
 {{- else -}}
   {{- randAlphaNum 48 -}}
 {{- end -}}
@@ -15,6 +18,9 @@ Generate password if not specified in values
 {{ define "agent.password" }}
 {{- if .Values.secrets.password }}
   {{- .Values.secrets.password -}}
+{{- else if (lookup "v1" "Secret" .Release.Namespace "agent-credentials").data }}
+  {{- $obj := (lookup "v1" "Secret" .Release.Namespace "agent-credentials").data -}}
+  {{- index $obj "password" | b64dec -}}
 {{- else -}}
   {{- randAlphaNum 48 -}}
 {{- end -}}


### PR DESCRIPTION
This PR fixes #10. Basically it updates the existing secret with either the value from the `secrets.username` and `secrets.password` variable if they are set. If not it checks if the existing secret has some values and will reuse them. Only if the secret is not existing it will generate a new username and password.