### PR TITLE
add service monitor for prometheus

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -52,6 +52,8 @@ helm delete crowdsec -n crowdsec
 | lapi.resources.limits.memory | string | `"100Mi"` |  |
 | lapi.resources.requests.cpu | string | `"150m"` |  |
 | lapi.resources.requests.memory | string | `"100Mi"` |  |
+| lapi.metrics.enabled | bool | `false` | Enables the metrics port 6060 for prometheus |
+| lapi.metrics.statusMonitor.enabled | bool | `false` | Creates a `ServiceMonitor` object for prometheus |
 | agent.acquisition[0] | object | `{"namespace":"ingress-nginx","podName":"ingress-nginx-controller-*","program":"nginx"}` | Specify each pod you want to process it logs (namespace, podName and program) |
 | agent.acquisition[0].podName | string | `"ingress-nginx-controller-*"` | to select pod logs to process |
 | agent.acquisition[0].program | string | `"nginx"` | program name related to specific parser you will use (see https://hub.crowdsec.net/author/crowdsecurity/configurations/docker-logs) |
@@ -59,4 +61,6 @@ helm delete crowdsec -n crowdsec
 | agent.resources.requests.cpu | string | `"150m"` |  |
 | agent.resources.requests.memory | string | `"100Mi"` |  |
 | agent.env | list | `[]` | environment variables from crowdsecurity/crowdsec docker image |
+| agent.metrics.enabled | bool | `false` | Enables the metrics port 6060 for prometheus |
+| agent.metrics.statusMonitor.enabled | bool | `false` | Creates a `ServiceMonitor` object for prometheus |
 

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -49,10 +49,12 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.agent.resources | nindent 10 }}
+        {{ if .Values.agent.metrics.enabled }}
         ports:
-          - name: agent-prom
+          - name: metrics
             containerPort: 6060
             protocol: TCP
+        {{ end }}
         volumeMounts:
           - name: acquis-config-volume
             mountPath: /etc/crowdsec/acquis.yaml

--- a/charts/crowdsec/templates/agent-service.yaml
+++ b/charts/crowdsec/templates/agent-service.yaml
@@ -1,15 +1,19 @@
+{{- if .Values.agent.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-agent-service
+  labels:
+    app: {{ .Release.Name }}-agent-service
 spec:
   type: ClusterIP
   ports:
     - port: 6060
       targetPort: 6060
       protocol: TCP
-      name: agent-prometheus
+      name: metrics
   selector:
     k8s-app: {{ .Release.Name }}
     type: agent
     version: v1
+{{- end -}}

--- a/charts/crowdsec/templates/agent-serviceMonitor.yaml
+++ b/charts/crowdsec/templates/agent-serviceMonitor.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.agent.metrics.enabled) (.Values.agent.metrics.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-agent-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-agent-service
+  namespaceSelector:
+    matchNames: [{{ .Release.Namespace }}]
+  endpoints:
+    - port: metrics
+{{ end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -54,9 +54,11 @@ spec:
           - name: lapi
             containerPort: 8080
             protocol: TCP
-          - name: lapi-prometheus
+            {{ if .Values.lapi.metrics.enabled }}
+          - name: metrics
             containerPort: 6060
             protocol: TCP
+            {{ end }}
       {{ if .Values.lapi.dashboard.enabled }}
         volumeMounts:
           - name: crowdsec-db

--- a/charts/crowdsec/templates/lapi-service.yaml
+++ b/charts/crowdsec/templates/lapi-service.yaml
@@ -2,13 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-service
+  labels:
+    app: {{ .Release.Name }}-service
 spec:
   type: ClusterIP
   ports:
+    {{ if .Values.lapi.metrics.enabled }}
     - port: 6060
       targetPort: 6060
       protocol: TCP
-      name: prometheus
+      name: metrics
+    {{ end }}
     - port: 8080
       targetPort: 8080
       protocol: TCP

--- a/charts/crowdsec/templates/lapi-serviceMonitor.yaml
+++ b/charts/crowdsec/templates/lapi-serviceMonitor.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.lapi.metrics.enabled) (.Values.lapi.metrics.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-service
+  namespaceSelector:
+    matchNames: [{{ .Release.Namespace }}]
+  endpoints:
+    - port: metrics
+{{ end }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -56,6 +56,11 @@ lapi:
       cpu: 150m
       memory: 100Mi
 
+  metrics:
+    enabled: false
+    serviceMonitor: 
+      enabled: false
+
 # agent will deploy pod on every node as daemonSet to read wanted pods logs
 agent:
   acquisition:
@@ -101,6 +106,11 @@ agent:
     #   value: "false"
     # - name: LEVEL_INFO
     #   value: "false"
+
+  metrics:
+    enabled: false
+    serviceMonitor: 
+      enabled: false
 
 #service: {}
 

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -56,8 +56,13 @@ lapi:
       cpu: 150m
       memory: 100Mi
 
+  # -- Enable service monitoring (exposes "metrics" port "6060" for Prometheus)
   metrics:
     enabled: false
+    # -- Creates a ServiceMonitor so Prometheus will monitor this service
+    # -- Prometheus needs to be configured to watch on all namespaces for ServiceMonitors
+    # -- See the documentation: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#prometheusioscrape
+    # -- See also: https://github.com/prometheus-community/helm-charts/issues/106#issuecomment-700847774
     serviceMonitor: 
       enabled: false
 
@@ -107,8 +112,13 @@ agent:
     # - name: LEVEL_INFO
     #   value: "false"
 
+  # -- Enable service monitoring (exposes "metrics" port "6060" for Prometheus)
   metrics:
     enabled: false
+    # -- Creates a ServiceMonitor so Prometheus will monitor this service
+    # -- Prometheus needs to be configured to watch on all namespaces for ServiceMonitors
+    # -- See the documentation: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#prometheusioscrape
+    # -- See also: https://github.com/prometheus-community/helm-charts/issues/106#issuecomment-700847774
     serviceMonitor: 
       enabled: false
 


### PR DESCRIPTION
This PR adds the possibility to enable or disable the metrics. If enabled there is also the possibility to deploy prometheus service monitors so prometheus can monitor the services. (Of course this only works if prometheus is configured to search in all namespaces for `ServiceMonitors`