### PR TITLE
handle json or CRI output logs

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/templates/acquis-configmap.yaml
+++ b/charts/crowdsec/templates/acquis-configmap.yaml
@@ -5,10 +5,11 @@ metadata:
 data:
   acquis.yaml: |-
     {{- $valid := required "You need to specify at least one pod for logs read" .Values.agent.acquisition }}
+    {{- $container_runtime := .Values.container_runtime }}
     {{- range .Values.agent.acquisition }}
     filenames:
       - /var/log/containers/{{ .podName }}_{{ .namespace }}_*.log
     labels:
-      type: docker
+      type: {{ $container_runtime }}
       program: {{ .program }}
     {{- end }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- for raw logs format: json or cri (docker|containerd)
+container_runtime: docker
+
 image:
   # -- docker image repository name
   repository: crowdsecurity/crowdsec


### PR DESCRIPTION
It will allow user to specify if crowdsec need to process json logs (when container runtime is Docker) or cri log format (when it's containerd)