### PR TITLE
Update ingress.yaml

### DIFF
--- a/charts/helloworld/templates/ingress.yaml
+++ b/charts/helloworld/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "helloworld.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}


### PR DESCRIPTION
If you try to intall this chart on a updated Kubernetes version you will get this error:

```
ubuntu@ubuntu ~> helm install helloworld crowdsec/helloworld
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"
```

This is because `networking.k8s.io/v1beta` is not longer supported. 

> The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22.
[Check Official kubernetes docs here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)

Updated to `networking.k8s.io/v1`