### PR TITLE
Update to work with latest version of kubernetes 02/22/22

### DIFF
--- a/charts/helloworld/templates/ingress.yaml
+++ b/charts/helloworld/templates/ingress.yaml
@@ -33,9 +33,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: {{ default "Prefix" }}
             backend:
-              service.name: {{ $fullName }}
-              service.port.name: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/helloworld/templates/ingress.yaml
+++ b/charts/helloworld/templates/ingress.yaml
@@ -34,8 +34,8 @@ spec:
           {{- range .paths }}
           - path: {{ .path }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service.name: {{ $fullName }}
+              service.port.name: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
If you try to intall this chart on a updated Kubernetes version you will get this error:

```
ubuntu@ubuntu ~> helm install helloworld crowdsec/helloworld
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"
```

This is because `networking.k8s.io/v1beta` is not longer supported. 

> The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22.
[Check Official kubernetes docs here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)

Updated to `networking.k8s.io/v1`