### PR TITLE
make wait-for-lapi image customizable

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -23,7 +23,8 @@ spec:
         effect: NoSchedule
       initContainers:
       - name: wait-for-lapi
-        image: busybox:1.28
+        image: "{{ .Values.agent.wait_for_lapi.image.repository }}:{{ .Values.agent.wait_for_lapi.image.tag }}"
+        imagePullPolicy: {{ .Values.agent.wait_for_lapi.image.pullPolicy }}
         command: ['sh', '-c', "until nc {{ .Release.Name }}-service.{{ .Release.Namespace }} 8080; do echo waiting for lapi to start; sleep 5; done"]
       containers:
       - name: crowdsec-agent

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -160,5 +160,15 @@ agent:
     serviceMonitor:
       enabled: false
 
+  # -- wait-for-lapi init container
+  wait_for_lapi:
+    image:
+      # -- docker image repository name
+      repository: busybox
+      # -- pullPolicy
+      pullPolicy: IfNotPresent
+      # -- docker image tag
+      tag: "1.28"
+
 #service: {}
 


### PR DESCRIPTION
Hi, there can be some problems with domain name resolution on busybox's uclibc version. It it could be nice to make wait-for-lapi image customizable.