### PR TITLE
Fix indentation for Ingress

### DIFF
--- a/charts/crowdsec/templates/metabase-ingress.yaml
+++ b/charts/crowdsec/templates/metabase-ingress.yaml
@@ -3,11 +3,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{ toYaml .Values.lapi.dashboard.ingress.annotations | indent 1 }}
+    {{- toYaml .Values.lapi.dashboard.ingress.annotations | nindent 4 }}
   name: {{ .Release.Namespace }}-dashboard
   labels:    
     {{- if .Values.lapi.dashboard.ingress.labels }}    
-    {{ toYaml .Values.lapi.dashboard.ingress.labels | indent 1 }}
+    {{- toYaml .Values.lapi.dashboard.ingress.labels | nindent 4 }}
     {{- else }}
     k8s-app: {{ .Release.Name }}
     type: lapi-dashboard
@@ -28,6 +28,6 @@ spec:
                   number: 3000    
   {{- if .Values.lapi.dashboard.ingress.tls }}
   tls:
-    {{ tpl (toYaml .Values.lapi.dashboard.ingress.tls | indent 1) . }}
+    {{- tpl (toYaml .Values.lapi.dashboard.ingress.tls | nindent 4) . }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
When setting multiple annotations the following error is returned :
```
Error: YAML parse error on crowdsec/templates/metabase-ingress.yaml: error converting YAML to JSON: yaml: line 5: did not find expected key
```
With the command `helm template crowdsec crowdsec/crowdsec -f crowdsec-values.yaml --debug` the following manifest is returned for the Ingress :
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    nginx.ingress.kubernetes.io/backend-protocol: HTTP
 traefik.ingress.kubernetes.io/router.entrypoints: websecure
 traefik.ingress.kubernetes.io/router.tls: "true"
  name: default-dashboard
  labels:
    k8s-app: crowdsec
    type: lapi-dashboard
    version: v1
spec:
  [...]
```
This PR fixes this issue by setting `nindent 4` instead of `indent 1`