### PR TITLE
make lapi deployment strategy configurable

### DIFF
--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -58,6 +58,7 @@ helm delete crowdsec -n crowdsec
 | lapi.tolerations | object | `{}` | tolerations for lapi |
 | lapi.metrics | object | `{"enabled":false,"serviceMonitor":{"enabled":false}}` | Enable service monitoring (exposes "metrics" port "6060" for Prometheus) |
 | lapi.metrics.serviceMonitor | object | `{"enabled":false}` | See also: https://github.com/prometheus-community/helm-charts/issues/106#issuecomment-700847774 |
+| lapi.strategy | object | `{"type":"RollingUpdate"}` | Strategy used to replace old lapi pods |
 | agent.acquisition[0] | object | `{"namespace":"ingress-nginx","podName":"ingress-nginx-controller-*","program":"nginx"}` | Specify each pod you want to process it logs (namespace, podName and program) |
 | agent.acquisition[0].podName | string | `"ingress-nginx-controller-*"` | to select pod logs to process |
 | agent.acquisition[0].program | string | `"nginx"` | program name related to specific parser you will use (see https://hub.crowdsec.net/author/crowdsecurity/configurations/docker-logs) |

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       k8s-app: {{ .Release.Name }}
       type: lapi
+  strategy: {{- toYaml .Values.lapi.strategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -90,6 +90,9 @@ lapi:
     serviceMonitor:
       enabled: false
 
+  strategy:
+    type: RollingUpdate
+
 # agent will deploy pod on every node as daemonSet to read wanted pods logs
 agent:
   acquisition:


### PR DESCRIPTION
LAPI deployment strategy needs to be configurable, for example when using PVC with accessMode ReadWriteOnce deployment cannot be updated with default RollingUpdate strategy