### PR TITLE
feat(agent) Use node name as agent name

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -33,9 +33,8 @@ spec:
         env:
           - name: AGENT_USERNAME
             valueFrom:
-              secretKeyRef:
-                name: agent-credentials
-                key: username
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: AGENT_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -18,8 +18,9 @@ spec:
         type: lapi
         version: v1
     spec:
-      {{ if .Values.lapi.dashboard.enabled }}
+      serviceAccountName: {{ .Release.Name }}-lapi
       initContainers:
+      {{ if .Values.lapi.dashboard.enabled }}
       - name: fetch-metabase-config
         image: busybox:1.28
         imagePullPolicy: IfNotPresent
@@ -28,21 +29,42 @@ spec:
         - name: shared-data
           mountPath: /metabase-data
       {{ end }}
-      containers:
-      - name: crowdsec-lapi
+      - name: kubectl
+        image: bitnami/kubectl
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -euxc
+        - kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' --no-headers > /etc/init/nodes.txt
+        volumeMounts:
+          - name: init
+            mountPath: /etc/init
+      - name: register
         image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.lapi.persistentVolume.config.enabled }}
+        command: ['sh', '-euc', 'mv -n /staging/etc/crowdsec/* /etc/crowdsec_data/ && rm -rf /staging/etc/crowdsec && ln -s /etc/crowdsec_data /etc/crowdsec && cp -r /staging/etc/* /etc/ && (cat /etc/init/nodes.txt | xargs -I{} cscli -c "/etc/crowdsec/config.yaml" machines add {} --password "$(AGENT_PASSWORD)")']
+        {{- else }}
+        command: ['sh', '-euc', 'cp -r /staging/etc/* /etc/ && (cat /etc/init/nodes.txt | xargs -I{} cscli -c "/etc/crowdsec/config.yaml" machines add {} --password "$(AGENT_PASSWORD)")']
+        {{- end }}
         env:
-          - name: AGENT_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: agent-credentials
-                key: username
           - name: AGENT_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: agent-credentials
                 key: password
+        volumeMounts:
+          - name: init
+            mountPath: /etc/init
+          - name: crowdsec-db
+            mountPath: /var/lib/crowdsec/data
+          - name: crowdsec-config
+            mountPath: /etc/crowdsec_data
+      containers:
+      - name: crowdsec-lapi
+        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
           - name: DISABLE_AGENT
             value: "true"
         {{- with .Values.lapi.env }}
@@ -62,17 +84,11 @@ spec:
         {{- if .Values.lapi.persistentVolume.config.enabled }}
         command: ['sh', '-c', 'mv -n /staging/etc/crowdsec/* /etc/crowdsec_data/ && rm -rf /staging/etc/crowdsec && ln -s /etc/crowdsec_data /etc/crowdsec && ./docker_start.sh']
         {{- end }}
-        {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) }}
         volumeMounts:
-          {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.dashboard.enabled) }}
           - name: crowdsec-db
             mountPath: /var/lib/crowdsec/data
-          {{- end }}
-          {{- if .Values.lapi.persistentVolume.config.enabled }}
           - name: crowdsec-config
             mountPath: /etc/crowdsec_data
-          {{- end }}
-        {{- end }}
       {{- if .Values.lapi.dashboard.enabled }}
       - name: dashboard
         image: "{{ .Values.lapi.dashboard.image.repository | default "metabase/metabase" }}:{{ .Values.lapi.dashboard.image.tag | default "latest" }}"
@@ -87,8 +103,9 @@ spec:
             value: /metabase-data/metabase.db
       {{- end }}
       terminationGracePeriodSeconds: 30
-      {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) }}
       volumes:
+      - name: init
+        emptyDir: {}
       {{- if .Values.lapi.dashboard.enabled }}
       - name: shared-data
         emptyDir: {}
@@ -97,7 +114,7 @@ spec:
       - name: crowdsec-db
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-db-pvc
-      {{- else if .Values.lapi.dashboard.enabled }}
+      {{- else }}
       - name: crowdsec-db
         emptyDir: {}
       {{- end }}
@@ -105,7 +122,9 @@ spec:
       - name: crowdsec-config
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-config-pvc
-      {{- end }}
+      {{- else }}
+      - name: crowdsec-config
+        emptyDir: {}
       {{- end }}
       {{- with .Values.lapi.tolerations }}
       tolerations:

--- a/charts/crowdsec/templates/lapi-rbac.yaml
+++ b/charts/crowdsec/templates/lapi-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-lapi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-lapi
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-lapi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-lapi
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-lapi
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Hello

The goal of this PR is to have 1 machines registered per agent.
If I am not wrong, the current helm chart registers 1 single machine through the env var `AGENT_USERNAME`.
Thanks to this PR, an agent will be registered for each kubernetes node.