### PR TITLE
fix(deployment): honor replicaCount value

### DIFF
--- a/charts/crowdsec-traefik-bouncer/templates/deployment.yaml
+++ b/charts/crowdsec-traefik-bouncer/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}


### PR DESCRIPTION
This honors the replicaCount value. This is already in values.yaml as well as the readme, it just was not used.