### PR TITLE
Add externalTrafficPolicy setting to services

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/templates/agent-service.yaml
+++ b/charts/crowdsec/templates/agent-service.yaml
@@ -24,6 +24,9 @@ spec:
   externalIPs:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if or (eq .Values.agent.service.type "LoadBalancer") (eq .Values.agent.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.agent.service.externalTrafficPolicy | quote }}
+  {{- end }}
   ports:
     - port: 6060
       targetPort: 6060

--- a/charts/crowdsec/templates/lapi-service.yaml
+++ b/charts/crowdsec/templates/lapi-service.yaml
@@ -23,6 +23,9 @@ spec:
   externalIPs:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if or (eq .Values.lapi.service.type "LoadBalancer") (eq .Values.lapi.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.lapi.service.externalTrafficPolicy | quote }}
+  {{- end }}
   ports:
     {{- if .Values.lapi.metrics.enabled }}
     - port: 6060

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -144,6 +144,7 @@ lapi:
     externalIPs: []
     loadBalancerIP: null
     loadBalancerClass: null
+    externalTrafficPolicy: Cluster
 
   # -- nodeSelector for lapi
   nodeSelector: {}
@@ -240,6 +241,7 @@ agent:
     externalIPs: []
     loadBalancerIP: null
     loadBalancerClass: null
+    externalTrafficPolicy: Cluster
 
   # -- wait-for-lapi init container
   wait_for_lapi:


### PR DESCRIPTION
This PR adds an option in the chart `crowdsec` to define the [externalTrafficPolicy](https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy) for agent and lapi services.
This setting is useful for preserving source IP when using services of type `LoadBalancer` and `NodePort`.