### PR TITLE
Add an optional ingress for lapi

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -55,6 +55,7 @@ helm delete crowdsec -n crowdsec
 | lapi.dashboard.image.tag | string | `"v0.41.5"` | docker image tag |
 | lapi.dashboard.assetURL | string | `"https://crowdsec-statics-assets.s3-eu-west-1.amazonaws.com/metabase_sqlite.zip"` | Metabase SQLite static DB containing Dashboards |
 | lapi.dashboard.ingress | object | `{"annotations":{"nginx.ingress.kubernetes.io/backend-protocol":"HTTP"},"enabled":false,"host":"","ingressClassName":""}` | Enable ingress object |
+| lapi.ingress | object | `{"annotations":{"nginx.ingress.kubernetes.io/backend-protocol":"HTTP"},"enabled":false,"host":"","ingressClassName":""}` | Enable ingress object |
 | lapi.resources.limits.memory | string | `"100Mi"` |  |
 | lapi.resources.requests.cpu | string | `"150m"` |  |
 | lapi.resources.requests.memory | string | `"100Mi"` |  |

--- a/charts/crowdsec/templates/NOTES.txt
+++ b/charts/crowdsec/templates/NOTES.txt
@@ -1,7 +1,11 @@
 Thank you for installing {{ .Chart.Name }}.
 
 ## Local API URL
+{{- if .Values.lapi.ingress.enabled }}
+http://{{ .Values.lapi.ingress.host }}
+{{- else }}
 http://{{ .Release.Name }}-service:8080
+{{- end }}
 
 {{ if .Values.lapi.dashboard.enabled }}
 ## Dashboard information

--- a/charts/crowdsec/templates/lapi-ingress.yaml
+++ b/charts/crowdsec/templates/lapi-ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.lapi.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    {{- toYaml .Values.lapi.ingress.annotations | nindent 4 }}
+  name: {{ .Release.Namespace }}-lapi
+  labels:    
+    {{- if .Values.lapi.ingress.labels }}    
+    {{- toYaml .Values.lapi.ingress.labels | nindent 4 }}
+    {{- else }}
+    k8s-app: {{ .Release.Name }}
+    type: lapi-api
+    version: v1
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.lapi.ingress.ingressClassName }}
+  rules:
+    - host: {{ .Values.lapi.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-service
+                port:
+                  number: 8080
+  {{- if .Values.lapi.ingress.tls }}
+  tls:
+    {{- tpl (toYaml .Values.lapi.ingress.tls | nindent 4) . }}
+  {{- end -}}
+{{- end -}}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -90,6 +90,17 @@ lapi:
     # by default disable the agent because it only the local API.
     #- name: DISABLE_AGENT
     #  value: "true"
+  # -- Enable ingress lapi object
+  ingress:
+    enabled: false
+    annotations:
+      # we only want http to the backend so we need this annotation
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    # labels: {}
+    ingressClassName: "" # nginx
+    host: "" # crowdsec-api.example.com
+    # tls: {}
+
   dashboard:
     # -- Enable Metabase Dashboard (by default disabled)
     enabled: false


### PR DESCRIPTION
Perhaps this works for #57 . This Adds an optional ingress for lapi traffic. This is a way a non-kubernetes agent and/or bouncer can communicate with the lapi api. Its mostly copy/pasta. I've tested this and it works in my environment. I have two ingress-controllers, one is internal and the other external.

crowdsec agent monitoring external ingress-nginx logs.
crowdsec lapi exposed on internal ingress-nginx
opnsense running crowdsec agent and bouncer registered with crowdsec lapi


I look forward to any feedback. 