### PR TITLE
Separate dashboard into it's own deployment and add persistence

### DIFF
--- a/charts/crowdsec/templates/NOTES.txt
+++ b/charts/crowdsec/templates/NOTES.txt
@@ -7,19 +7,19 @@ http://{{ .Values.lapi.ingress.host }}
 http://{{ .Release.Name }}-service:8080
 {{- end }}
 
-{{ if .Values.lapi.dashboard.enabled }}
+{{ if .Values.dashboard.enabled }}
 ## Dashboard information
 
 You can access to the dashboard using : 
-{{- if .Values.lapi.dashboard.ingress.enabled }}
-    {{- if .Values.lapi.dashboard.ingress.tls }}
-    {{- with (index .Values.lapi.dashboard.ingress.tls 0) }}
+{{- if .Values.dashboard.ingress.enabled }}
+    {{- if .Values.dashboard.ingress.tls }}
+    {{- with (index .Values.dashboard.ingress.tls 0) }}
     {{- range .hosts }}
 https://{{- . }}
     {{- end }}
     {{- end }}
     {{- else }}
-http://{{- .Values.lapi.dashboard.ingress.host }}
+http://{{- .Values.dashboard.ingress.host }}
     {{end}}
 {{- else }}
 http://{{ .Release.Name }}-service

--- a/charts/crowdsec/templates/dashboard-deployment.yaml
+++ b/charts/crowdsec/templates/dashboard-deployment.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-dashboard
+  labels:
+    k8s-app: {{ .Release.Name }}
+    type: dashboard
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      k8s-app: {{ .Release.Name }}
+      type: dashboard
+      version: v1
+  strategy: {{- toYaml .Values.dashboard.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{ .Release.Name }}
+        type: dashboard
+        version: v1
+    spec:
+      initContainers:
+        - name: fetch-metabase-config
+          image: busybox:1.28
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', 'wget {{ .Values.dashboard.assetURL }} && unzip metabase_sqlite.zip -n -d /metabase-data/']
+          volumeMounts:
+          - name: shared-data
+            mountPath: /metabase-data
+      containers:
+        - name: dashboard
+          image: metabase/metabase:v0.41.5
+          command:
+            - sh
+            - '-c'
+            - >-
+              ln -fs /var/lib/crowdsec/data/crowdsec.db /metabase-data/crowdsec.db
+              && /app/run_metabase.sh
+          env:
+            - name: MB_DB_FILE
+              value: /metabase-data/metabase.db
+            - name: MGID
+              value: '1000'
+            - name: GID
+              value: '1000'
+          resources: {{- toYaml .Values.dashboard.resources | nindent 12 }}
+          volumeMounts:
+            - name: shared-data
+              mountPath: /metabase-data
+            - name: crowdsec-db
+              mountPath: /var/lib/crowdsec/data
+          ports:
+          - containerPort: 3000
+            name: dashboard
+            protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      volumes:
+      - name: shared-data
+        {{- if .Values.dashboard.persistentVolume.enabled }}
+        persistentVolumeClaim:
+            {{ if .Values.dashboard.persistentVolume.existingClaim }}
+            claimName: {{ .Values.dashboard.persistentVolume.existingClaim }}
+            {{ else }}
+            claimName: {{ .Release.Name }}-dashboard-pvc
+            {{ end }}
+        {{ else }}
+        emptyDir: {}
+        {{ end }}
+      - name: crowdsec-db
+        persistentVolumeClaim:
+          {{ if .Values.lapi.persistentVolume.data.existingClaim }}
+          claimName: {{ .Values.lapi.persistentVolume.data.existingClaim }}
+          {{ else }}
+          claimName: {{ .Release.Name }}-db-pvc
+          {{ end }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.dashboard.tolerations }}
+      tolerations:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.nodeSelector }}
+      nodeSelector:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.affinity }}
+      affinity:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/crowdsec/templates/dashboard-persistentVolume.yaml
+++ b/charts/crowdsec/templates/dashboard-persistentVolume.yaml
@@ -1,0 +1,27 @@
+{{- if and (.Values.dashboard.enabled) (.Values.dashboard.persistentVolume.enabled) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-dashboard-pvc
+  {{- if .Values.dashboard.persistentVolume.annotations }}
+  annotations:
+{{ toYaml .Values.dashboard.persistentVolume.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    k8s-app: {{ .Release.Name }}
+    type: agent
+    version: v1
+spec:
+  accessModes:
+{{ toYaml .Values.dashboard.persistentVolume.accessModes | indent 4 }}
+{{- if .Values.dashboard.persistentVolume.storageClassName }}
+{{- if (eq "-" .Values.dashboard.persistentVolume.storageClassName) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.dashboard.persistentVolume.storageClassName }}"
+{{- end }}
+{{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.dashboard.persistentVolume.size }}"
+{{ end }}

--- a/charts/crowdsec/templates/dashboard-service.yaml
+++ b/charts/crowdsec/templates/dashboard-service.yaml
@@ -1,0 +1,39 @@
+{{- if (.Values.dashboard.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-dashboard-service
+  labels:
+    app: {{ .Release.Name }}-dashboard--service
+    {{- with .Values.dashboard.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.dashboard.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.dashboard.service.type }}
+  {{- with .Values.dashboard.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with .Values.dashboard.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  {{- with .Values.dashboard.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if or (eq .Values.dashboard.service.type "LoadBalancer") (eq .Values.dashboard.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.dashboard.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: dashboard
+  selector:
+    k8s-app: {{ .Release.Name }}
+    type: dashboard
+    version: v1
+{{ end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -19,16 +19,6 @@ spec:
         type: lapi
         version: v1
     spec:
-      {{ if .Values.lapi.dashboard.enabled }}
-      initContainers:
-      - name: fetch-metabase-config
-        image: busybox:1.28
-        imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'wget {{ .Values.lapi.dashboard.assetURL }} && unzip metabase_sqlite.zip -d /metabase-data/']
-        volumeMounts:
-        - name: shared-data
-          mountPath: /metabase-data
-      {{- end }}
       containers:
       - name: crowdsec-lapi
         image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -46,10 +36,6 @@ spec:
                 key: password
           - name: DISABLE_AGENT
             value: "true"
-          {{- if .Values.lapi.dashboard.enabled }}
-          - name: GID
-            value: "1000"
-          {{- end }}
         {{- with .Values.lapi.env }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -67,9 +53,9 @@ spec:
         {{ if .Values.lapi.persistentVolume.config.enabled }}
         command: ['sh', '-c', 'mv -n /staging/etc/crowdsec/* /etc/crowdsec_data/ && rm -rf /staging/etc/crowdsec && ln -s /etc/crowdsec_data /etc/crowdsec && ./docker_start.sh']
         {{ end }}
-        {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) }}
+        {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) }}
         volumeMounts:
-          {{ if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.dashboard.enabled) }}
+          {{ if or (.Values.lapi.persistentVolume.data.enabled) (.Values.dashboard.enabled) }}
           - name: crowdsec-db
             mountPath: /var/lib/crowdsec/data
           {{ end }}
@@ -99,29 +85,9 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-      {{- if .Values.lapi.dashboard.enabled }}
-      - name: dashboard
-        image: "{{ .Values.lapi.dashboard.image.repository | default "metabase/metabase" }}:{{ .Values.lapi.dashboard.image.tag | default "latest" }}"
-        imagePullPolicy: {{ .Values.lapi.dashboard.image.pullPolicy }}
-        command: ['sh', '-c', 'ln -fs /var/lib/crowdsec/data/crowdsec.db /metabase-data/crowdsec.db && /app/run_metabase.sh']
-        volumeMounts:
-        - name: shared-data
-          mountPath: /metabase-data
-        - name: crowdsec-db
-          mountPath: /var/lib/crowdsec/data
-        env:
-          - name: MB_DB_FILE
-            value: /metabase-data/metabase.db
-          - name: MGID
-            value: "1000"
-      {{- end }}
       terminationGracePeriodSeconds: 30
-      {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) }}
+      {{- if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) }}
       volumes:
-      {{- if .Values.lapi.dashboard.enabled }}
-      - name: shared-data
-        emptyDir: {}
-      {{- end }}
       {{- if .Values.lapi.persistentVolume.data.enabled }}
       - name: crowdsec-db
         persistentVolumeClaim:
@@ -130,7 +96,7 @@ spec:
           {{ else }}
           claimName: {{ .Release.Name }}-db-pvc
           {{ end }}
-      {{- else if .Values.lapi.dashboard.enabled }}
+      {{- else if .Values.dashboard.enabled }}
       - name: crowdsec-db
         emptyDir: {}
       {{- end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     type: lapi
     version: v1
 spec:
+  replicas: {{ .Values.lapi.replicas }}
   selector:
     matchLabels:
       k8s-app: {{ .Release.Name }}

--- a/charts/crowdsec/templates/lapi-service.yaml
+++ b/charts/crowdsec/templates/lapi-service.yaml
@@ -37,12 +37,6 @@ spec:
       targetPort: 8080
       protocol: TCP
       name: lapi
-    {{- if .Values.lapi.dashboard.enabled }}
-    - port: 3000
-      targetPort: 3000
-      protocol: TCP
-      name: dashboard
-    {{- end }}
   selector:
     k8s-app: {{ .Release.Name }}
     type: lapi

--- a/charts/crowdsec/templates/metabase-ingress.yaml
+++ b/charts/crowdsec/templates/metabase-ingress.yaml
@@ -1,33 +1,33 @@
-{{- if and (.Values.lapi.dashboard.enabled) (.Values.lapi.dashboard.ingress.enabled) }}
+{{- if and (.Values.dashboard.enabled) (.Values.dashboard.ingress.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{- toYaml .Values.lapi.dashboard.ingress.annotations | nindent 4 }}
+    {{- toYaml .Values.dashboard.ingress.annotations | nindent 4 }}
   name: {{ .Release.Namespace }}-dashboard
   labels:    
-    {{- if .Values.lapi.dashboard.ingress.labels }}    
-    {{- toYaml .Values.lapi.dashboard.ingress.labels | nindent 4 }}
+    {{- if .Values.dashboard.ingress.labels }}    
+    {{- toYaml .Values.dashboard.ingress.labels | nindent 4 }}
     {{- else }}
     k8s-app: {{ .Release.Name }}
     type: lapi-dashboard
     version: v1
     {{- end }}
 spec:
-  ingressClassName: {{ .Values.lapi.dashboard.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.dashboard.ingress.ingressClassName }}
   rules:
-    - host: {{ .Values.lapi.dashboard.ingress.host }}
+    - host: {{ .Values.dashboard.ingress.host }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ .Release.Name }}-service
+                name: {{ .Release.Name }}-dashboard-service
                 port:
                   number: 3000    
-  {{- if .Values.lapi.dashboard.ingress.tls }}
+  {{- if .Values.dashboard.ingress.tls }}
   tls:
-    {{- tpl (toYaml .Values.lapi.dashboard.ingress.tls | nindent 4) . }}
+    {{- tpl (toYaml .Values.dashboard.ingress.tls | nindent 4) . }}
   {{- end -}}
 {{- end -}}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -83,6 +83,55 @@ secrets:
   # -- agent password (default is generated randomly)
   password: ""
 
+
+dashboard:
+  # -- Enable Metabase Dashboard (by default disabled)
+  enabled: false
+  image:
+    # -- docker image repository name
+    repository: metabase/metabase
+    # -- pullPolicy
+    pullPolicy: IfNotPresent
+    # -- docker image tag
+    tag: "v0.41.5"
+  # -- Metabase SQLite static DB containing Dashboards
+  assetURL: https://crowdsec-statics-assets.s3-eu-west-1.amazonaws.com/metabase_sqlite.zip
+  persistentVolume:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: ""
+    existingClaim: ""
+    size: 100Mi
+  service:
+    type: ClusterIP
+    labels: {}
+    annotations: {}
+    externalIPs: []
+    loadBalancerIP: null
+    loadBalancerClass: null
+    externalTrafficPolicy: Cluster
+  resources: {}
+  # -- Enable ingress object
+  ingress:
+    enabled: false
+    annotations:
+      # metabase only supports http so we need this annotation
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    # labels: {}
+    ingressClassName: "" # nginx
+    host: "" # metabase.example.com
+    # tls: {}
+    affinity:
+      podAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: type
+              operator: In
+              values:
+              - lapi
+          topologyKey: "kubernetes.io/hostname"
 # lapi will deploy pod with crowdsec lapi and dashboard as deployment
 lapi:
   # -- environment variables from crowdsecurity/crowdsec docker image
@@ -100,31 +149,6 @@ lapi:
     ingressClassName: "" # nginx
     host: "" # crowdsec-api.example.com
     # tls: {}
-
-  dashboard:
-    # -- Enable Metabase Dashboard (by default disabled)
-    enabled: false
-    image:
-      # -- docker image repository name
-      repository: metabase/metabase
-      # -- pullPolicy
-      pullPolicy: IfNotPresent
-      # -- docker image tag
-      tag: "v0.41.5"
-    # -- Metabase SQLite static DB containing Dashboards
-    assetURL: https://crowdsec-statics-assets.s3-eu-west-1.amazonaws.com/metabase_sqlite.zip
-
-    # -- Enable ingress object
-    ingress:
-      enabled: false
-      annotations:
-        # metabase only supports http so we need this annotation
-        nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-      # labels: {}
-      ingressClassName: "" # nginx
-      host: "" # metabase.example.com
-      # tls: {}
-
   resources:
     limits:
       memory: 100Mi

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -134,6 +134,7 @@ dashboard:
           topologyKey: "kubernetes.io/hostname"
 # lapi will deploy pod with crowdsec lapi and dashboard as deployment
 lapi:
+  replicas: 1
   # -- environment variables from crowdsecurity/crowdsec docker image
   env: []
     # by default disable the agent because it only the local API.


### PR DESCRIPTION
Hi,

This is still a work in progress and requires some testing, but I've done some work around fixing https://github.com/crowdsecurity/helm-charts/issues/55 so that the dashboard is able to persist changes.

I've also split the dashboard out into a separate deployment so the the LAPI can be run in a high-availability configuration without also having multiple instances of the dashboard running (which consumes significant memory).

Here's a summary of the changes I've made:

1. Split the dashboard into a separate deployment manifest with it's own service and ingress.
2. Added persistent volume configuration for the dashboard.
3. Modified the initContainer command for the dashboard so that it does not overwrite the user's existing database.
4. Updated `values.yaml` accordingly with a dedicated section for the dashboard. By default, I've set a `podAffinity` so that the dashboard is scheduled onto the same node as the LAPI so that this still works if the user only has access to `ReadWriteOnce` storage classes.
5. Added a `replicas` field for the LAPI deployment to allow for it to be deployed in a high-availability configuration.

It would be great if I could get some feedback around the direction I'm taking this in. We're using this fork of the Helm chart internally to run a HA CrowdSec LAPI and would like to contribute these changes back.
