### PR TITLE
release 0.8.1

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -48,4 +48,4 @@ version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.4.3
+appVersion: v1.4.4-rc1

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -1,6 +1,6 @@
 # crowdsec
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.3](https://img.shields.io/badge/AppVersion-v1.4.3-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.4-rc1](https://img.shields.io/badge/AppVersion-v1.4.4-rc1-informational?style=flat-square)
 
 Crowdsec helm chart is an open-source, lightweight agent to detect and respond to malicious behaviors.
 

--- a/charts/crowdsec/templates/acquis-configmap.yaml
+++ b/charts/crowdsec/templates/acquis-configmap.yaml
@@ -12,6 +12,7 @@ data:
     ---
     filenames:
       - /var/log/containers/{{ .podName }}_{{ .namespace }}_*.log
+    force_inotify: true
     labels:
       type: {{ $container_runtime }}
       program: {{ .program }}

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -37,6 +37,8 @@ spec:
         env:
           - name: DISABLE_LOCAL_API
             value: "true"
+          - name: DISABLE_ONLINE_API
+            value: "true"
 
           # agent - lapi authentication, with TLS or password
 


### PR DESCRIPTION
 - use crowdsec 1.4.4-rc1 by default
 - disable capi in agents (avoid wasteful register)
 - enable force_inotify (also fixes the tls tutorial)