### PR TITLE
tls updates for 1.4.4-rc3

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,9 +43,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.4.4-rc1
+appVersion: v1.4.4-rc3

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -47,15 +47,13 @@ helm delete crowdsec -n crowdsec
 | config."profiles.yaml" | string | `""` | Profiles configuration (https://docs.crowdsec.net/docs/next/profiles/format/#profile-configuration-example) |
 | config.notifications | object | `{}` | notifications configuration (https://docs.crowdsec.net/docs/next/notification_plugins/intro) |
 | tls.enabled | bool | `false` |  |
+| tls.caBundle | bool | `true` |  | whether the tls secrets contain a ca.crt file
 | tls.certManager.enabled | bool | `true` |  |
 | tls.agent.secret | string | `"{{ .Release.Name }}-agent-tls"` |  |
 | tls.agent.reflector.namespaces | list | `[]` |  |
-| tls.agent.caBundle | bool | `true` |  | whether the agent-tls secret contains a ca.crt file
 | tls.bouncer.secret | string | `"{{ .Release.Name }}-bouncer-tls"` |  |
 | tls.bouncer.reflector.namespaces | list | `[]` |  |
-| tls.bouncer.caBundle | bool | `true` |  | whether the bouncer-tls secret contains a ca.crt file
 | tls.lapi.secret | string | `"{{ .Release.Name }}-lapi-tls"` |  |
-| tls.lapi.caBundle | bool | `true` |  | whether the lapi-tls secret contains a ca.crt file
 | secrets.username | string | `""` | agent username (default is generated randomly) |
 | secrets.password | string | `""` | agent password (default is generated randomly) |
 | lapi.env | list | `[]` | environment variables from crowdsecurity/crowdsec docker image |

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -47,13 +47,15 @@ helm delete crowdsec -n crowdsec
 | config."profiles.yaml" | string | `""` | Profiles configuration (https://docs.crowdsec.net/docs/next/profiles/format/#profile-configuration-example) |
 | config.notifications | object | `{}` | notifications configuration (https://docs.crowdsec.net/docs/next/notification_plugins/intro) |
 | tls.enabled | bool | `false` |  |
-| tls.caBundle | bool | `true` |  |
 | tls.certManager.enabled | bool | `true` |  |
-| tls.bouncer.secret | string | `"{{ .Release.Name }}-bouncer-tls"` |  |
-| tls.bouncer.reflector.namespaces | list | `[]` |  |
 | tls.agent.secret | string | `"{{ .Release.Name }}-agent-tls"` |  |
 | tls.agent.reflector.namespaces | list | `[]` |  |
+| tls.agent.caBundle | bool | `true` |  | whether the agent-tls secret contains a ca.crt file
+| tls.bouncer.secret | string | `"{{ .Release.Name }}-bouncer-tls"` |  |
+| tls.bouncer.reflector.namespaces | list | `[]` |  |
+| tls.bouncer.caBundle | bool | `true` |  | whether the bouncer-tls secret contains a ca.crt file
 | tls.lapi.secret | string | `"{{ .Release.Name }}-lapi-tls"` |  |
+| tls.lapi.caBundle | bool | `true` |  | whether the lapi-tls secret contains a ca.crt file
 | secrets.username | string | `""` | agent username (default is generated randomly) |
 | secrets.password | string | `""` | agent password (default is generated randomly) |
 | lapi.env | list | `[]` | environment variables from crowdsecurity/crowdsec docker image |

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -51,6 +51,8 @@ helm delete crowdsec -n crowdsec
 | tls.certManager.enabled | bool | `true` |  |
 | tls.agent.secret | string | `"{{ .Release.Name }}-agent-tls"` |  |
 | tls.agent.reflector.namespaces | list | `[]` |  |
+| tls.agent.tlsAuth | bool | `true` | authenticate with client certificate (no username/password) |
+| tls.agent.insecureSkipVerify | bool | `false` | skip lapi certificate validation |
 | tls.bouncer.secret | string | `"{{ .Release.Name }}-bouncer-tls"` |  |
 | tls.bouncer.reflector.namespaces | list | `[]` |  |
 | tls.lapi.secret | string | `"{{ .Release.Name }}-lapi-tls"` |  |

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -51,7 +51,7 @@ spec:
             value: /etc/ssl/crowdsec/tls.crt
           - name: KEY_FILE
             value: /etc/ssl/crowdsec/tls.key
-          {{- if .Values.tls.caBundle }}
+          {{- if .Values.tls.agent.caBundle }}
           - name: CACERT_FILE
             value: /etc/ssl/crowdsec/ca.crt
           {{- end }}

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -47,17 +47,21 @@ spec:
             value: https://{{ .Release.Name }}-service.{{ .Release.Namespace }}:8080
           - name: USE_TLS
             value: "true"
+          {{- if .Values.tls.agent.tlsAuth }}
           - name: CLIENT_CERT_FILE
             value: /etc/ssl/crowdsec-agent/tls.crt
           - name: CLIENT_KEY_FILE
             value: /etc/ssl/crowdsec-agent/tls.key
+          {{- end }}
           {{- if .Values.tls.caBundle }}
-          - name: CLIENT_CACERT_FILE
+          - name: CACERT_FILE
             value: /etc/ssl/crowdsec-agent/ca.crt
           {{- end }}
           {{- else }}
           - name: LOCAL_API_URL
             value: http://{{ .Release.Name }}-service.{{ .Release.Namespace }}:8080
+          {{- end }}
+          {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsAuth) }}
           - name: AGENT_USERNAME
             valueFrom:
               secretKeyRef:
@@ -68,6 +72,10 @@ spec:
               secretKeyRef:
                 name: agent-credentials
                 key: password
+          {{- end }}
+          {{- if .Values.tls.insecureSkipVerify }}
+          - name: INSECURE_SKIP_VERIFY
+            value: {{ quote .Values.tls.insecureSkipVerify }}
           {{- end }}
 
         {{- with .Values.agent.env }}

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -47,13 +47,13 @@ spec:
             value: https://{{ .Release.Name }}-service.{{ .Release.Namespace }}:8080
           - name: USE_TLS
             value: "true"
-          - name: CERT_FILE
-            value: /etc/ssl/crowdsec/tls.crt
-          - name: KEY_FILE
-            value: /etc/ssl/crowdsec/tls.key
-          {{- if .Values.tls.agent.caBundle }}
-          - name: CACERT_FILE
-            value: /etc/ssl/crowdsec/ca.crt
+          - name: CLIENT_CERT_FILE
+            value: /etc/ssl/crowdsec-agent/tls.crt
+          - name: CLIENT_KEY_FILE
+            value: /etc/ssl/crowdsec-agent/tls.key
+          {{- if .Values.tls.caBundle }}
+          - name: CLIENT_CACERT_FILE
+            value: /etc/ssl/crowdsec-agent/ca.crt
           {{- end }}
           {{- else }}
           - name: LOCAL_API_URL
@@ -134,8 +134,8 @@ spec:
             mountPath: /var/lib/docker/containers
             readOnly: true
           {{- if .Values.tls.enabled }}
-          - name: crowdsec-tls
-            mountPath: /etc/ssl/crowdsec
+          - name: crowdsec-agent-tls
+            mountPath: /etc/ssl/crowdsec-agent
           {{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
@@ -201,7 +201,7 @@ spec:
         hostPath:
           path: /var/lib/docker/containers
       {{- if .Values.tls.enabled }}
-      - name: crowdsec-tls
+      - name: crowdsec-agent-tls
         secret:
           secretName: {{ .Release.Name }}-agent-tls
       {{- end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             value: /etc/ssl/crowdsec/tls.crt
           - name: KEY_FILE
             value: /etc/ssl/crowdsec/tls.key
-          {{- if .Values.tls.caBundle }}
+          {{- if .Values.tls.lapi.caBundle }}
           - name: CACERT_FILE
             value: /etc/ssl/crowdsec/ca.crt
           {{- end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           - name: LOCAL_API_URL
             value: http://{{ .Release.Name }}-service.{{ .Release.Namespace }}:8080
           {{- end }}
-          {{- if not .Values.tls.enabled }}
+          {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsAuth) }}
           - name: AGENT_USERNAME
             valueFrom:
               secretKeyRef:
@@ -65,21 +65,24 @@ spec:
           {{- if .Values.tls.enabled }}
           - name: USE_TLS
             value: "true"
-          - name: CLIENT_CERT_FILE
-            value: /etc/ssl/crowdsec-agent/tls.crt
-          - name: CLIENT_KEY_FILE
-            value: /etc/ssl/crowdsec-agent/tls.key
           - name: LAPI_CERT_FILE
             value: /etc/ssl/crowdsec-lapi/tls.crt
           - name: LAPI_KEY_FILE
             value: /etc/ssl/crowdsec-lapi/tls.key
+          {{- if .Values.tls.agent.tlsAuth }}
+          - name: CLIENT_CERT_FILE
+            value: /etc/ssl/crowdsec-agent/tls.crt
+          - name: CLIENT_KEY_FILE
+            value: /etc/ssl/crowdsec-agent/tls.key
+          {{- end }}
           {{- if .Values.tls.caBundle }}
-          - name: CLIENT_CACERT_FILE
-            value: /etc/ssl/crowdsec-agent/ca.crt
-          - name: LAPI_CACERT_FILE
+          - name: CACERT_FILE
             value: /etc/ssl/crowdsec-lapi/ca.crt
           {{- end }}
           {{- end }}
+          - name: INSECURE_SKIP_VERIFY
+            value: {{ quote .Values.tls.insecureSkipVerify }}
+
         {{- with .Values.lapi.env }}
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -37,6 +37,13 @@ spec:
         image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+          {{- if .Values.tls.enabled }}
+          - name: LOCAL_API_URL
+            value: https://{{ .Release.Name }}-service.{{ .Release.Namespace }}:8080
+          {{- else }}
+          - name: LOCAL_API_URL
+            value: http://{{ .Release.Name }}-service.{{ .Release.Namespace }}:8080
+          {{- end }}
           {{- if not .Values.tls.enabled }}
           - name: AGENT_USERNAME
             valueFrom:
@@ -58,13 +65,19 @@ spec:
           {{- if .Values.tls.enabled }}
           - name: USE_TLS
             value: "true"
-          - name: CERT_FILE
-            value: /etc/ssl/crowdsec/tls.crt
-          - name: KEY_FILE
-            value: /etc/ssl/crowdsec/tls.key
-          {{- if .Values.tls.lapi.caBundle }}
-          - name: CACERT_FILE
-            value: /etc/ssl/crowdsec/ca.crt
+          - name: CLIENT_CERT_FILE
+            value: /etc/ssl/crowdsec-agent/tls.crt
+          - name: CLIENT_KEY_FILE
+            value: /etc/ssl/crowdsec-agent/tls.key
+          - name: LAPI_CERT_FILE
+            value: /etc/ssl/crowdsec-lapi/tls.crt
+          - name: LAPI_KEY_FILE
+            value: /etc/ssl/crowdsec-lapi/tls.key
+          {{- if .Values.tls.caBundle }}
+          - name: CLIENT_CACERT_FILE
+            value: /etc/ssl/crowdsec-agent/ca.crt
+          - name: LAPI_CACERT_FILE
+            value: /etc/ssl/crowdsec-lapi/ca.crt
           {{- end }}
           {{- end }}
         {{- with .Values.lapi.env }}
@@ -87,8 +100,10 @@ spec:
         {{- if or (.Values.tls.enabled) (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) }}
         volumeMounts:
           {{- if .Values.tls.enabled }}
-          - name: crowdsec-tls
-            mountPath: /etc/ssl/crowdsec
+          - name: crowdsec-lapi-tls
+            mountPath: /etc/ssl/crowdsec-lapi
+          - name: crowdsec-agent-tls
+            mountPath: /etc/ssl/crowdsec-agent
           {{- end }}
           {{ if or (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.dashboard.enabled) }}
           - name: crowdsec-db
@@ -187,9 +202,12 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.tls.enabled }}
-      - name: crowdsec-tls
+      - name: crowdsec-lapi-tls
         secret:
           secretName: {{ .Release.Name }}-lapi-tls
+      - name: crowdsec-agent-tls
+        secret:
+          secretName: {{ .Release.Name }}-agent-tls
       {{- end }}
       {{- end }}
       {{- with .Values.lapi.tolerations }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -76,19 +76,21 @@ config:
 
 tls:
   enabled: false
-  caBundle: true
   certManager:
     enabled: true
   bouncer:
     secret: "{{ .Release.Name }}-bouncer-tls"
+    caBundle: true
     reflector:
       namespaces: []
   agent:
     secret: "{{ .Release.Name }}-agent-tls"
+    caBundle: true
     reflector:
       namespaces: []
   lapi:
     secret: "{{ .Release.Name }}-lapi-tls"
+    caBundle: true
 
 # If you want to specify secrets that will be used for all your crowdsec-agents
 # secrets can be provided as env variables

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/crowdsecurity/helm-charts/main/charts/crowdsec/values.schema.json
+
 # Default values for crowdsec-chart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -76,21 +78,19 @@ config:
 
 tls:
   enabled: false
+  caBundle: true
   certManager:
     enabled: true
   bouncer:
     secret: "{{ .Release.Name }}-bouncer-tls"
-    caBundle: true
     reflector:
       namespaces: []
   agent:
     secret: "{{ .Release.Name }}-agent-tls"
-    caBundle: true
     reflector:
       namespaces: []
   lapi:
     secret: "{{ .Release.Name }}-lapi-tls"
-    caBundle: true
 
 # If you want to specify secrets that will be used for all your crowdsec-agents
 # secrets can be provided as env variables

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -79,6 +79,7 @@ config:
 tls:
   enabled: false
   caBundle: true
+  insecureSkipVerify: false
   certManager:
     enabled: true
   bouncer:
@@ -86,6 +87,7 @@ tls:
     reflector:
       namespaces: []
   agent:
+    tlsAuth: true
     secret: "{{ .Release.Name }}-agent-tls"
     reflector:
       namespaces: []


### PR DESCRIPTION
 - updated to work with 1.4.4-rc3 (separate client / lapi certs)
 - added tlsAuth, insecureSkipVerify
 - allow use of CA with user/pw auth