### PR TITLE
add `machine` label to servicemonitors

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -43,7 +43,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.5
+version: 0.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/templates/agent-serviceMonitor.yaml
+++ b/charts/crowdsec/templates/agent-serviceMonitor.yaml
@@ -13,6 +13,13 @@ spec:
       app: {{ .Release.Name }}-agent-service
   namespaceSelector:
     matchNames: [{{ .Release.Namespace }}]
+  attachMetadata:
+    node: true
   endpoints:
     - port: metrics
+      relabelings:
+      - action: replace
+        sourceLabels:
+        - __meta_kubernetes_pod_node_name
+        targetLabel: machine
 {{ end }}

--- a/charts/crowdsec/templates/lapi-serviceMonitor.yaml
+++ b/charts/crowdsec/templates/lapi-serviceMonitor.yaml
@@ -13,6 +13,13 @@ spec:
       app: {{ .Release.Name }}-service
   namespaceSelector:
     matchNames: [{{ .Release.Namespace }}]
+  attachMetadata:
+    node: true
   endpoints:
     - port: metrics
+      relabelings:
+        - action: replace
+          sourceLabels:
+          - __meta_kubernetes_pod_node_name
+          targetLabel: machine
 {{ end }}


### PR DESCRIPTION
A small tweak to servicemonitor to add `machine` label based on node name
Added because by default the v4 Grafana dashboards rely on it