### PR TITLE
Mount /var/log as readOnly

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -152,6 +152,7 @@ spec:
             subPath: acquis.yaml
           - name: varlog
             mountPath: /var/log
+            readOnly: true
           {{- if (eq "docker" .Values.container_runtime) }}
           - name: varlibdockercontainers
             mountPath: /var/lib/docker/containers


### PR DESCRIPTION
The agent DaemonSet needs to mount `/var/log` to parse node logs. However, on GKE Autopilot clusters, `hostPath` mounts are required to be in `readOnly` mode, making the `crowdsec` chart unusable on the platform: 
```
admission webhook "warden-validating.common-webhooks.networking.gke.io" denied the request: GKE Warden rejected the request because it violates one or more constraints. 
Violations details: {"[denied by autogke-no-write-mode-hostpath]":["hostPath volume varlog in container crowdsec-agent is accessed in write mode; disallowed in Autopilot."]}
```

Mounting `/var/log` as readOnly would fix the issue and doesn't seem to affect how Crowdsec works.