### PR TITLE
Add option for poll_without_inotify

### DIFF
--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -87,9 +87,10 @@ helm delete crowdsec -n crowdsec
 | lapi.metrics.serviceMonitor | object | `{"enabled":false}` | See also: https://github.com/prometheus-community/helm-charts/issues/106#issuecomment-700847774 |
 | lapi.strategy.type | string | `"RollingUpdate"` |  |
 | agent.additionalAcquisition | list | `[]` | To add custom acquisitions using available datasources (https://docs.crowdsec.net/docs/next/data_sources/intro) |
-| agent.acquisition[0] | object | `{"namespace":"","podName":"","program":""}` | Specify each pod you want to process it logs (namespace, podName and program) |
+| agent.acquisition[0] | object | `{"namespace":"","podName":"","poll_without_inotify":false,"program":""}` | Specify each pod you want to process it logs (namespace, podName and program) |
 | agent.acquisition[0].podName | string | `""` | to select pod logs to process |
 | agent.acquisition[0].program | string | `""` | program name related to specific parser you will use (see https://hub.crowdsec.net/author/crowdsecurity/configurations/docker-logs) |
+| agent.acquisition[0].poll_without_inotify | bool | `false` | If set to true, will poll the files using os.Stat instead of using inotify |
 | agent.resources.limits.memory | string | `"100Mi"` |  |
 | agent.resources.requests.cpu | string | `"150m"` |  |
 | agent.resources.requests.memory | string | `"100Mi"` |  |

--- a/charts/crowdsec/templates/acquis-configmap.yaml
+++ b/charts/crowdsec/templates/acquis-configmap.yaml
@@ -13,6 +13,7 @@ data:
     filenames:
       - /var/log/containers/{{ .podName }}_{{ .namespace }}_*.log
     force_inotify: true
+    poll_without_inotify: {{ .poll_without_inotify | default "false"}}
     labels:
       type: {{ $container_runtime }}
       program: {{ .program }}

--- a/charts/crowdsec/values.schema.json
+++ b/charts/crowdsec/values.schema.json
@@ -83,6 +83,10 @@
                 "program": {
                     "type": "string",
                     "minLength": 1
+                },
+                "poll_without_inotify": {
+                    "type": "boolean",
+                    "default": false
                 }
             },
             "required": [

--- a/charts/crowdsec/values.schema.json
+++ b/charts/crowdsec/values.schema.json
@@ -168,6 +168,11 @@
                     "default": false,
                     "description": "If set to true, force an inotify watch on the log files folder, even if there is no log in it."
                 },
+                "poll_without_inotify": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If set to true, will poll the files using os.Stat instead of using inotify"
+                },
                 "filenames": {
                     "type": "array",
                     "items": {

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -232,6 +232,8 @@ agent:
       podName: "" #ingress-nginx-controller-*
       # -- program name related to specific parser you will use (see https://hub.crowdsec.net/author/crowdsecurity/configurations/docker-logs)
       program: "" #nginx
+      # -- If set to true, will poll the files using os.Stat instead of using inotify
+      poll_without_inotify: false
   resources:
     limits:
       memory: 100Mi


### PR DESCRIPTION
Adds the option poll_without_inotify to pod and file acquisitions to match the currently documented option at https://docs.crowdsec.net/docs/data_sources/file