### PR TITLE
Support for LAPI High availability

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -39,14 +39,15 @@ description: |
 
   # Configure external DB (https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example)
   config:
-    config-override.yaml: |
+    config.yaml.local: |
       db_config:
-        type:     "postgresql"
-        user:     "crowdsec"
-        password: "${DB_PASSWORD}"
-        db_name:  "crowdsec"
-        host:     "192.168.0.2"
-        port:     "5432"
+        type:     postgresql
+        user:     crowdsec
+        password: ${DB_PASSWORD}
+        db_name:  crowdsec
+        host:     192.168.0.2
+        port:     5432
+        sslmode:  require
 
   lapi:
     # 2 or more replicas for HA

--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -30,6 +30,49 @@ description: |
   helm delete crowdsec -n crowdsec
   ```
 
+  ## Setup for High Availability
+
+  Below a basic configuration for High availability
+
+  ```
+  # your-values.yaml
+
+  # Configure external DB (https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example)
+  config:
+    config-override.yaml: |
+      db_config:
+        type:     "postgresql"
+        user:     "crowdsec"
+        password: "${DB_PASSWORD}"
+        db_name:  "crowdsec"
+        host:     "192.168.0.2"
+        port:     "5432"
+
+  lapi:
+    # 2 or more replicas for HA
+    replicas: 2
+    # You can specify your own CS_LAPI_SECRET, or let the chart generate one. Length must be >= 64
+    secrets:
+      csLapiSecret: <anyRandomSecret>
+    # Specify your external DB password here
+    extraSecrets:
+      dbPassword: <externalDbPassword>
+    persistentVolume:
+      # When replicas for LAPI is greater than 1, two options, persistent volumes must be disabled, or in ReadWriteMany mode
+      config:
+        enabled: false
+      # data volume is not required, since SQLite isn't used
+      data:
+        enabled: false
+    # DB Password passed through environment variable
+    env:
+      - name: DB_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: crowdsec-lapi-secrets
+            key: dbPassword
+  ```
+
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -49,6 +49,7 @@ helm delete crowdsec -n crowdsec
 | config."console.yaml" | string | `""` |  |
 | config."capi_whitelists.yaml" | string | `""` |  |
 | config."profiles.yaml" | string | `""` | Profiles configuration (https://docs.crowdsec.net/docs/next/profiles/format/#profile-configuration-example) |
+| config."config-override.yaml" | string | `""` | General configuration (https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example) |
 | config.notifications | object | `{}` | notifications configuration (https://docs.crowdsec.net/docs/next/notification_plugins/intro) |
 | tls.enabled | bool | `false` |  |
 | tls.caBundle | bool | `true` |  |
@@ -62,6 +63,7 @@ helm delete crowdsec -n crowdsec
 | tls.lapi.secret | string | `"{{ .Release.Name }}-lapi-tls"` |  |
 | secrets.username | string | `""` | agent username (default is generated randomly) |
 | secrets.password | string | `""` | agent password (default is generated randomly) |
+| lapi.replicas | int | `1` | replicas for local API |
 | lapi.env | list | `[]` | environment variables from crowdsecurity/crowdsec docker image |
 | lapi.ingress | object | `{"annotations":{"nginx.ingress.kubernetes.io/backend-protocol":"HTTP"},"enabled":false,"host":"","ingressClassName":""}` | Enable ingress lapi object |
 | lapi.priorityClassName | string | `""` | pod priority class name |
@@ -95,6 +97,9 @@ helm delete crowdsec -n crowdsec
 | lapi.metrics | object | `{"enabled":false,"serviceMonitor":{"enabled":false}}` | Enable service monitoring (exposes "metrics" port "6060" for Prometheus) |
 | lapi.metrics.serviceMonitor | object | `{"enabled":false}` | See also: https://github.com/prometheus-community/helm-charts/issues/106#issuecomment-700847774 |
 | lapi.strategy.type | string | `"Recreate"` |  |
+| lapi.topologySpreadConstraints | object | `{}` | topologySpreadConstraints for lapi |
+| lapi.secrets.csLapiSecret | string | `""` | Shared LAPI secret. Will be generated randomly if not specified. Size must be > 64 characters |
+| lapi.extraSecrets | object | `{}` | Any extra secrets you may need (for example, external DB password) |
 | agent.additionalAcquisition | list | `[]` | To add custom acquisitions using available datasources (https://docs.crowdsec.net/docs/next/data_sources/intro) |
 | agent.acquisition[0] | object | `{"namespace":"","podName":"","poll_without_inotify":false,"program":""}` | Specify each pod you want to process it logs (namespace, podName and program) |
 | agent.acquisition[0].podName | string | `""` | to select pod logs to process |

--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -49,7 +49,7 @@ helm delete crowdsec -n crowdsec
 | config."console.yaml" | string | `""` |  |
 | config."capi_whitelists.yaml" | string | `""` |  |
 | config."profiles.yaml" | string | `""` | Profiles configuration (https://docs.crowdsec.net/docs/next/profiles/format/#profile-configuration-example) |
-| config."config-override.yaml" | string | `""` | General configuration (https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example) |
+| config."config.yaml.local" | string | `""` | General configuration (https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example) |
 | config.notifications | object | `{}` | notifications configuration (https://docs.crowdsec.net/docs/next/notification_plugins/intro) |
 | tls.enabled | bool | `false` |  |
 | tls.caBundle | bool | `true` |  |
@@ -94,6 +94,7 @@ helm delete crowdsec -n crowdsec
 | lapi.tolerations | list | `[]` | tolerations for lapi |
 | lapi.dnsConfig | object | `{}` | dnsConfig for lapi |
 | lapi.affinity | object | `{}` | affinity for lapi |
+| lapi.topologySpreadConstraints | object | `[]` | topologySpreadConstraints for lapi |
 | lapi.metrics | object | `{"enabled":false,"serviceMonitor":{"enabled":false}}` | Enable service monitoring (exposes "metrics" port "6060" for Prometheus) |
 | lapi.metrics.serviceMonitor | object | `{"enabled":false}` | See also: https://github.com/prometheus-community/helm-charts/issues/106#issuecomment-700847774 |
 | lapi.strategy.type | string | `"Recreate"` |  |

--- a/charts/crowdsec/templates/_helpers.tpl
+++ b/charts/crowdsec/templates/_helpers.tpl
@@ -78,7 +78,7 @@ true
   lapi custom config check
 */}}
 {{ define "lapiCustomConfigIsNotEmpty" }}
-{{- if or (index .Values.config "profiles.yaml") (index .Values.config "config-override.yaml") ((include "notificationsIsNotEmpty" .)) }}
+{{- if or (index .Values.config "profiles.yaml") (index .Values.config "config.yaml.local") ((include "notificationsIsNotEmpty" .)) }}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/crowdsec/templates/_helpers.tpl
+++ b/charts/crowdsec/templates/_helpers.tpl
@@ -30,6 +30,20 @@ Generate password if not specified in values
 {{- end -}}
 
 {{/*
+Generate CS_LAPI_SECRET if not specified in values
+*/}}
+{{ define "lapi.csLapiSecret" }}
+{{- if .Values.lapi.secrets.csLapiSecret }}
+  {{- .Values.lapi.secrets.csLapiSecret -}}
+{{- else if (lookup "v1" "Secret" .Release.Namespace "crowdsec-lapi-secrets").data }}
+  {{- $obj := (lookup "v1" "Secret" .Release.Namespace "crowdsec-lapi-secrets").data -}}
+  {{- index $obj "csLapiSecret" | b64dec -}}
+{{- else -}}
+  {{- randAscii 64 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
   notifications parameters check
 */}}
 {{ define "notificationsIsNotEmpty" }}
@@ -64,7 +78,7 @@ true
   lapi custom config check
 */}}
 {{ define "lapiCustomConfigIsNotEmpty" }}
-{{- if or (index .Values.config "profiles.yaml") ((include "notificationsIsNotEmpty" .)) }}
+{{- if or (index .Values.config "profiles.yaml") (index .Values.config "config-override.yaml") ((include "notificationsIsNotEmpty" .)) }}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/crowdsec/templates/lapi-configmap.yaml
+++ b/charts/crowdsec/templates/lapi-configmap.yaml
@@ -29,6 +29,16 @@ data:
   capi_whitelists.yaml: |
 {{ printf "%+v" (index .Values.config "capi_whitelists.yaml") | indent 4 }}
 {{ end }}
+{{- if index .Values.config "config-override.yaml" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: crowdsec-config-override
+data:
+  config.yaml.local: |
+{{ printf "%+v" (index .Values.config "config-override.yaml") | indent 4 }}
+{{ end }}
 {{ if (include "notificationsIsNotEmpty" .) }}
 ---
 apiVersion: v1

--- a/charts/crowdsec/templates/lapi-configmap.yaml
+++ b/charts/crowdsec/templates/lapi-configmap.yaml
@@ -29,15 +29,15 @@ data:
   capi_whitelists.yaml: |
 {{ printf "%+v" (index .Values.config "capi_whitelists.yaml") | indent 4 }}
 {{ end }}
-{{- if index .Values.config "config-override.yaml" }}
+{{- if index .Values.config "config.yaml.local" }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: crowdsec-config-override
+  name: crowdsec-config-local
 data:
   config.yaml.local: |
-{{ printf "%+v" (index .Values.config "config-override.yaml") | indent 4 }}
+{{ printf "%+v" (index .Values.config "config.yaml.local") | indent 4 }}
 {{ end }}
 {{ if (include "notificationsIsNotEmpty" .) }}
 ---

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     type: lapi
     version: v1
 spec:
+  replicas: {{ .Values.lapi.replicas }}
   selector:
     matchLabels:
       k8s-app: {{ .Release.Name }}
@@ -103,6 +104,11 @@ spec:
           - name: CAPI_WHITELISTS_PATH
             value: "/etc/crowdsec/capi_whitelists.yaml"
           {{- end }}
+          - name: CS_LAPI_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: crowdsec-lapi-secrets
+                key: csLapiSecret
 
         {{- with .Values.lapi.env }}
           {{- toYaml . | nindent 10 }}
@@ -199,6 +205,11 @@ spec:
           - name: crowdsec-capi-whitelists-volume
             mountPath: {{ $crowdsecConfig }}/capi_whitelists.yaml
             subPath: capi_whitelists.yaml
+          {{ end }}
+          {{ if index .Values.config "config-override.yaml" }}
+          - name: crowdsec-config-override-volume
+            mountPath: {{ $crowdsecConfig }}/config.yaml.local
+            subPath: config.yaml.local
           {{ end }}
           {{- if (include "notificationsIsNotEmpty" .) -}}
           {{ range $fileName, $content := .Values.config.notifications -}}
@@ -313,6 +324,11 @@ spec:
         configMap:
           name: crowdsec-capi-whitelists
       {{- end }}
+      {{ if index .Values.config "config-override.yaml" }}
+      - name: crowdsec-config-override-volume
+        configMap:
+          name: crowdsec-config-override
+      {{- end }}
       {{- if (include "notificationsIsNotEmpty" .) -}}
       {{ range $fileName, $content := .Values.config.notifications -}}
       {{- if $content }}
@@ -348,6 +364,10 @@ spec:
       {{- end }}
       {{- with .Values.lapi.affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lapi.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       priorityClassName: {{ .Values.lapi.priorityClassName }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -206,8 +206,8 @@ spec:
             mountPath: {{ $crowdsecConfig }}/capi_whitelists.yaml
             subPath: capi_whitelists.yaml
           {{ end }}
-          {{ if index .Values.config "config-override.yaml" }}
-          - name: crowdsec-config-override-volume
+          {{ if index .Values.config "config.yaml.local" }}
+          - name: crowdsec-config-local-volume
             mountPath: {{ $crowdsecConfig }}/config.yaml.local
             subPath: config.yaml.local
           {{ end }}
@@ -324,10 +324,10 @@ spec:
         configMap:
           name: crowdsec-capi-whitelists
       {{- end }}
-      {{ if index .Values.config "config-override.yaml" }}
-      - name: crowdsec-config-override-volume
+      {{ if index .Values.config "config.yaml.local" }}
+      - name: crowdsec-config-local-volume
         configMap:
-          name: crowdsec-config-override
+          name: crowdsec-config-local
       {{- end }}
       {{- if (include "notificationsIsNotEmpty" .) -}}
       {{ range $fileName, $content := .Values.config.notifications -}}

--- a/charts/crowdsec/templates/lapi-secrets.yaml
+++ b/charts/crowdsec/templates/lapi-secrets.yaml
@@ -1,0 +1,19 @@
+# vim: set ft=gotmpl:
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crowdsec-lapi-secrets
+  labels:
+    k8s-app: {{ .Release.Name }}
+    type: lapi
+    version: v1
+type: Opaque
+data:
+  csLapiSecret: {{ include "lapi.csLapiSecret" . | b64enc }}
+  {{- with .Values.lapi.extraSecrets }}
+  {{- range $key, $value := . }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
+  {{- end }}

--- a/charts/crowdsec/values.schema.json
+++ b/charts/crowdsec/values.schema.json
@@ -126,7 +126,7 @@
                 "capi_whitelists.yaml": {
                     "type": "string"
                 },
-                "config-override.yaml": {
+                "config.yaml.local": {
                     "type": "string"
                 }
             },

--- a/charts/crowdsec/values.schema.json
+++ b/charts/crowdsec/values.schema.json
@@ -125,6 +125,9 @@
                 },
                 "capi_whitelists.yaml": {
                     "type": "string"
+                },
+                "config-override.yaml": {
+                    "type": "string"
                 }
             },
             "title": "Config"

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -81,15 +81,16 @@ config:
     #    - Alert.Remediation == true && Alert.GetScope() == "Ip"
     #  ...
   # -- General configuration (https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example)
-  config-override.yaml: ""
+  config.yaml.local: ""
     #   |
     # db_config:
-    #   type:     "postgresql"
-    #   user:     "crowdsec"
-    #   password: "${DB_PASSWORD}"
-    #   db_name:  "crowdsec"
-    #   host:     "192.168.0.2"
-    #   port:     "5432"
+    #   type:     postgresql
+    #   user:     crowdsec
+    #   password: ${DB_PASSWORD}
+    #   db_name:  crowdsec
+    #   host:     192.168.0.2
+    #   port:     5432
+    #   sslmode:  require
   # -- notifications configuration (https://docs.crowdsec.net/docs/next/notification_plugins/intro)
   notifications: {}
     # email.yaml: |
@@ -236,7 +237,7 @@ lapi:
   # -- affinity for lapi
   affinity: {}
   # -- topologySpreadConstraints for lapi
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
 
   # -- Enable service monitoring (exposes "metrics" port "6060" for Prometheus)
   metrics:

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -80,6 +80,16 @@ config:
     #  filters:
     #    - Alert.Remediation == true && Alert.GetScope() == "Ip"
     #  ...
+  # -- General configuration (https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example)
+  config-override.yaml: ""
+    #   |
+    # db_config:
+    #   type:     "postgresql"
+    #   user:     "crowdsec"
+    #   password: "${DB_PASSWORD}"
+    #   db_name:  "crowdsec"
+    #   host:     "192.168.0.2"
+    #   port:     "5432"
   # -- notifications configuration (https://docs.crowdsec.net/docs/next/notification_plugins/intro)
   notifications: {}
     # email.yaml: |
@@ -120,6 +130,8 @@ secrets:
 
 # lapi will deploy pod with crowdsec lapi and dashboard as deployment
 lapi:
+  # -- replicas for local API
+  replicas: 1
   # -- environment variables from crowdsecurity/crowdsec docker image
   env: []
     # by default disable the agent because it only needs the local API.
@@ -223,6 +235,8 @@ lapi:
   dnsConfig: {}
   # -- affinity for lapi
   affinity: {}
+  # -- topologySpreadConstraints for lapi
+  topologySpreadConstraints: {}
 
   # -- Enable service monitoring (exposes "metrics" port "6060" for Prometheus)
   metrics:
@@ -236,6 +250,13 @@ lapi:
 
   strategy:
     type: Recreate
+
+  secrets:
+    # -- Shared LAPI secret. Will be generated randomly if not specified. Size must be > 64 characters
+    csLapiSecret: ""
+  # -- Any extra secrets you may need (for example, external DB password)
+  extraSecrets: {}
+    # dbPassword: randomPass
 
 # agent will deploy pod on every node as daemonSet to read wanted pods logs
 agent:


### PR DESCRIPTION
- Add "lapi.replicas" in values and deployment templates
- Add "lapi.affinity" in values.yaml, as it was missing, and thus not included in the the documentation
- Add "lapi.topologySpreadConstraints" in values and deployment template.
- Add a configuration override, to be able to configure and external DB (among other things, as described [here](https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example)). It creates a "config.yaml.local" file in the crowdsec config directory, so default config values are kept.
- Add "lapi.secrets.csLapiSecret" in values, create a secret and define it as env vars for deployment. This is required because it must be identical for every lapi pods. It will be generated automatically if not specified by the user.
- Add "lapi.extraSecrets" to allow users to specify any extra secrets for lapi. They can then be used as env vars (needed to pass the external DB password for example)
- Document HA in Chart.yaml.