### PR TITLE
dnsConfig support for alpine linux

### DIFF
--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -323,6 +323,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.lapi.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.lapi.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -198,7 +198,7 @@ lapi:
   nodeSelector: {}
   # -- tolerations for lapi
   tolerations: {}
-  # -- dnsConfig for for lapi
+  # -- dnsConfig for lapi
   dnsConfig: {}
 
   # -- Enable service monitoring (exposes "metrics" port "6060" for Prometheus)

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -198,6 +198,8 @@ lapi:
   nodeSelector: {}
   # -- tolerations for lapi
   tolerations: {}
+  # -- dnsConfig for for lapi
+  dnsConfig: {}
 
   # -- Enable service monitoring (exposes "metrics" port "6060" for Prometheus)
   metrics:


### PR DESCRIPTION
Alpine linux image does not handle well DNS resolution when used with Rancher Kubernetes type distribution.

You need to add this in Deployment to be able to resolve hostnames:
```yaml
      dnsConfig:
        options:
          - name: ndots
            value: '1'
```