### PR TITLE
Adding priorityClassName

### DIFF
--- a/charts/crowdsec-traefik-bouncer/templates/deployment.yaml
+++ b/charts/crowdsec-traefik-bouncer/templates/deployment.yaml
@@ -68,3 +68,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/crowdsec-traefik-bouncer/values.yaml
+++ b/charts/crowdsec-traefik-bouncer/values.yaml
@@ -53,3 +53,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+priorityClassName: ""

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -240,3 +240,4 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      priorityClassName: {{ .Values.agent.priorityClassName }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -327,3 +327,4 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      priorityClassName: {{ .Values.lapi.priorityClassName }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -127,6 +127,9 @@ lapi:
     host: "" # crowdsec-api.example.com
     # tls: {}
 
+  # -- pod priority class name
+  priorityClassName: ""
+
   dashboard:
     # -- Enable Metabase Dashboard (by default disabled)
     enabled: false
@@ -234,6 +237,10 @@ agent:
       program: "" #nginx
       # -- If set to true, will poll the files using os.Stat instead of using inotify
       poll_without_inotify: false
+
+  # -- pod priority class name
+  priorityClassName: ""
+  
   resources:
     limits:
       memory: 100Mi


### PR DESCRIPTION
Adds the option to set an existing `priorityClassName`. This means we would be able to ensure Crowdsec gets scheduled on a particular set of nodes we have.