### PR TITLE
adding v0.1 of governance bot

### DIFF
--- a/.github/governance.yaml
+++ b/.github/governance.yaml
@@ -2,7 +2,7 @@ version: v1
 
 issue:
   automations:
-    autoAssignAnyFrom: ['@he2ss', '@blotus', '@buixor', '@LaurenceJJones']
+    autoAssignAnyFrom: ['@he2ss', '@blotus', '@buixor', '@mmetc','@LaurenceJJones']
     autoStale:
       fromTag: 'provide more details'
       delay: '30d'

--- a/.github/governance.yaml
+++ b/.github/governance.yaml
@@ -1,0 +1,118 @@
+version: v1
+
+issue:
+  automations:
+    autoAssignAnyFrom: ['@he2ss', '@blotus', '@buixor', '@LaurenceJJones']
+    autoStale:
+      fromTag: 'provide more details'
+      delay: '30d'
+      resetOn: ['issue_comment/created']
+    autoClose:
+      fromTag: 'stale'
+      delay: '60d'
+
+  # captures:
+  #   - regex: 'version: v*(.+)-[rc*]?'
+  #     github_release: true
+  #     ignore_case: true
+  #     label: 'version/$CAPTURED'
+
+  #   - regex: 'Platform: *(windows?|ms|wins?|microsoft).*'
+  #     label: 'os/win'
+  #     ignore_case: true
+    
+  #   - regex: 'Platform: *(freebsd|bsd).*'
+  #     label: 'os/freebsd'
+  #     ignore_case: true
+
+  #   - regex: 'Platform: *(linux|linus|lin).*'
+  #     label: 'os/linux'
+  #     ignore_case: true
+
+  #   - regex: 'Platform: *(macos|mac|apple|macintosh|macbook).*'
+  #     label: 'os/mac'
+  #     ignore_case: true
+
+  labels:
+    - prefix: triage
+      list: ['accepted']
+      multiple: false
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+      needs:
+        comment: |
+          @$AUTHOR: Thanks for opening an issue, it is currently awaiting triage.
+
+          If you haven't already, please provide the following information:
+          * kind : `bug`, `enhancement`or `documentation`
+          * area : `agent`, `appsec`, `configuration`, `cscli`, `local-api`
+
+          In the meantime, you can:
+
+          1. Check [Crowdsec Documentation](https://docs.crowdsec.net/) to see if your issue can be self resolved.
+          2. You can also join our [Discord](https://discord.gg/crowdsec).
+          3. Check [Releases](https://github.com/crowdsecurity/crowdsec/releases/latest) to make sure your agent is on the latest version.
+
+    - prefix: kind
+      list: ['bug', 'enhancement', 'documentation']
+      multiple: false
+      author_association:
+        author: true
+        collaborator: true
+        member: true
+        owner: true
+      needs:
+        comment: |
+          @$AUTHOR: There are no 'kind' label on this issue. You need a 'kind' label to start the triage process.
+          * `/kind bug`
+          * `/kind documentation`
+          * `/kind enhancement`
+  
+  chat_ops:
+    - cmd: /assign
+      type: assign
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+
+pull_request:
+  labels:
+    - prefix: kind
+      multiple: false
+      list: [ 'feature', 'enhancement', 'fix', 'chore', 'dependencies']
+      needs:
+        comment: |
+          @$AUTHOR: There are no 'kind' label on this PR. You need a 'kind' label to generate the release automatically.
+          * `/kind feature`
+          * `/kind enhancement`
+          * `/kind fix`
+          * `/kind chore`
+          * `/kind dependencies`
+        status:
+          context: 'Kind Label'
+          description:
+            success: Ready for review & merge.
+            failure: Missing kind label to generate release automatically.
+
+    - prefix: area
+      list: [ "agent", "local-api", "cscli", "security", "configuration"]
+      multiple: true
+      needs:
+        comment: |
+          @$AUTHOR: There are no area labels on this PR. You can add as many areas as you see fit.
+          * `/area agent`
+          * `/area local-api`
+          * `/area cscli`
+          * `/area security`
+          * `/area configuration`
+
+    # - prefix: priority
+    #   multiple: false
+    #   list: [ 'urgent', 'important' ]
+    #   author_association:
+    #     collaborator: true
+    #     member: true
+    #     owner: true

--- a/.github/workflows/governance-bot.yaml
+++ b/.github/workflows/governance-bot.yaml
@@ -1,0 +1,34 @@
+# .github/governance.yml
+
+on:
+  pull_request_target:
+    types: [ synchronize, opened, labeled, unlabeled ]
+  issues:
+    types: [ opened, labeled, unlabeled ]
+  issue_comment:
+    types: [ created ]
+  # Scheduled events cron // Scheduled automations are: autoStale & autoClose
+  # Set to check every hour for now, could be every day at 1 : '0 1 * * *'
+  schedule:
+    - cron: '0 * * * *'
+
+# You can use permissions to modify the default permissions granted to the GITHUB_TOKEN, 
+# adding or removing access as required, so that you only allow the minimum required access. 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
+
+jobs:
+  governance:
+    name: Governance
+    runs-on: ubuntu-latest
+    steps:
+      # Semantic versioning, lock to different version: v2, v2.0 or a commit hash.
+      - uses: rr404/oss-governance-bot@main
+        with:
+          # You can use a PAT to post a comment/label/status so that it shows up as a user instead of github-actions
+          # github-token: ${{secrets.GITHUB_TOKEN}} # optional, default to '${{ github.token }}'
+          config-path: .github/governance.yml # optional, default to '.github/governance.yml'


### PR DESCRIPTION
In this PR the governance bot is setup to:
* autoassign one among '@he2ss', '@blotus', '@buixor', '@mmetc', '@LaurenceJJones'
* request kind to be set on issues and kind+area on pr

* Tag issue as 'stale' avec 30d of tag ''provide more details'
* Close issue staged 'stale' after 60d without activity
