### PR TITLE
uncomment github-token param for gov bot config

### DIFF
--- a/.github/workflows/governance-bot.yaml
+++ b/.github/workflows/governance-bot.yaml
@@ -30,5 +30,5 @@ jobs:
       - uses: rr404/oss-governance-bot@main
         with:
           # You can use a PAT to post a comment/label/status so that it shows up as a user instead of github-actions
-          # github-token: ${{secrets.GITHUB_TOKEN}} # optional, default to '${{ github.token }}'
+          github-token: ${{secrets.GITHUB_TOKEN}} # optional, default to '${{ github.token }}'
           config-path: .github/governance.yml # optional, default to '.github/governance.yml'


### PR DESCRIPTION
I forgot to uncomment the github token param, so this Pr fixes it