### PR TITLE
Add support for custom tls issuer

### DIFF
--- a/charts/crowdsec/templates/tls/agent-certificate.yaml
+++ b/charts/crowdsec/templates/tls/agent-certificate.yaml
@@ -17,7 +17,12 @@ spec:
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
       {{ end }}
   issuerRef:
+    {{ if .Values.tls.certManager.issuerRef }}
+    name: {{ .Values.tls.certManager.issuerRef.name }}
+    kind: {{ default "Issuer" .Values.tls.certManager.issuerRef.kind }}
+    {{ else }}
     name: {{ .Release.Name }}-ca-issuer
+    {{ end }}
   subject:
     organizationalUnits:
       - agent-ou

--- a/charts/crowdsec/templates/tls/bouncer-certificate.yaml
+++ b/charts/crowdsec/templates/tls/bouncer-certificate.yaml
@@ -17,7 +17,12 @@ spec:
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
       {{ end }}
   issuerRef:
+    {{ if .Values.tls.certManager.issuerRef }}
+    name: {{ .Values.tls.certManager.issuerRef.name }}
+    kind: {{ default "Issuer" .Values.tls.certManager.issuerRef.kind }}
+    {{ else }}
     name: {{ .Release.Name }}-ca-issuer
+    {{ end }}
   subject:
     organizationalUnits:
       - bouncer-ou

--- a/charts/crowdsec/templates/tls/ca-certificate.yaml
+++ b/charts/crowdsec/templates/tls/ca-certificate.yaml
@@ -1,6 +1,6 @@
 # vim: set ft=gotmpl:
 ---
-{{ if and (.Values.tls.enabled) (.Values.tls.certManager.enabled) }}
+{{ if and (.Values.tls.enabled) (.Values.tls.certManager.enabled) (not .Values.tls.certManager.issuerRef) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/crowdsec/templates/tls/ca-issuer.yaml
+++ b/charts/crowdsec/templates/tls/ca-issuer.yaml
@@ -1,6 +1,6 @@
 # vim: set ft=gotmpl:
 ---
-{{ if and (.Values.tls.enabled) (.Values.tls.certManager.enabled) }}
+{{ if and (.Values.tls.enabled) (.Values.tls.certManager.enabled) (not .Values.tls.certManager.issuerRef) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/charts/crowdsec/templates/tls/crowdsec-clusterIssuer.yaml
+++ b/charts/crowdsec/templates/tls/crowdsec-clusterIssuer.yaml
@@ -1,6 +1,6 @@
 # vim: set ft=gotmpl:
 ---
-{{ if and (.Values.tls.enabled) (.Values.tls.certManager.enabled) }}
+{{ if and (.Values.tls.enabled) (.Values.tls.certManager.enabled) (not .Values.tls.certManager.issuerRef) }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/crowdsec/templates/tls/lapi-certificate.yaml
+++ b/charts/crowdsec/templates/tls/lapi-certificate.yaml
@@ -13,5 +13,10 @@ spec:
     - localhost
   secretName: {{ .Release.Name }}-lapi-tls
   issuerRef:
+    {{ if .Values.tls.certManager.issuerRef }}
+    name: {{ .Values.tls.certManager.issuerRef.name }}
+    kind: {{ default "Issuer" .Values.tls.certManager.issuerRef.kind }}
+    {{ else }}
     name: {{ .Release.Name }}-ca-issuer
+    {{ end }}
 {{ end }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -109,6 +109,10 @@ tls:
   insecureSkipVerify: false
   certManager:
     enabled: true
+    # -- Use existing issuer to sign certificates. Leave empty to generate a self-signed issuer
+    issuerRef: {}
+      # name: ""
+      # kind: "ClusterIssuer"
   bouncer:
     secret: "{{ .Release.Name }}-bouncer-tls"
     reflector:


### PR DESCRIPTION
Allows configuration of custom Issuer or ClusterIssuer when TLS is enabled using cert-manager.

Related issues: #93 