### PR TITLE
Add duration and renewBefore values for cert-manager certificates

### DIFF
--- a/charts/crowdsec/templates/tls/agent-certificate.yaml
+++ b/charts/crowdsec/templates/tls/agent-certificate.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   commonName: CrowdSec Agent
   secretName: {{ .Release.Name }}-agent-tls
+  duration: {{ .Values.tls.certManager.duration }}
+  renewBefore: {{ .Values.tls.certManager.renewBefore }}
   secretTemplate:
     annotations:
       {{ if .Values.tls.agent.reflector.namespaces }}

--- a/charts/crowdsec/templates/tls/bouncer-certificate.yaml
+++ b/charts/crowdsec/templates/tls/bouncer-certificate.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   commonName: CrowdSec Bouncer
   secretName: {{ .Release.Name }}-bouncer-tls
+  duration: {{ .Values.tls.certManager.duration }}
+  renewBefore: {{ .Values.tls.certManager.renewBefore }}
   secretTemplate:
     annotations:
       {{ if .Values.tls.bouncer.reflector.namespaces }}

--- a/charts/crowdsec/templates/tls/lapi-certificate.yaml
+++ b/charts/crowdsec/templates/tls/lapi-certificate.yaml
@@ -12,6 +12,8 @@ spec:
     - {{ .Release.Name }}-service.{{ .Release.Namespace }}.svc.cluster.local
     - localhost
   secretName: {{ .Release.Name }}-lapi-tls
+  duration: {{ .Values.tls.certManager.duration }}
+  renewBefore: {{ .Values.tls.certManager.renewBefore }}
   issuerRef:
     {{ if .Values.tls.certManager.issuerRef }}
     name: {{ .Values.tls.certManager.issuerRef.name }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -113,6 +113,10 @@ tls:
     issuerRef: {}
       # name: ""
       # kind: "ClusterIssuer"
+    # -- duration for Certificate resources
+    duration: 2160h # 90d
+    # -- renewBefore for Certificate resources
+    renewBefore: 720h # 30d
   bouncer:
     secret: "{{ .Release.Name }}-bouncer-tls"
     reflector:


### PR DESCRIPTION
Add options to configure ```duration``` and ```renewBefore``` fields for Certificates resources.
Default values are set to cert-manager's default, ```duration = 90d```, and ```renewBefore = 30d```.