### PR TITLE
Add annotations to LAPI deploy, Agent daemonset and secretTemplate for certificates

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -9,6 +9,10 @@ metadata:
     k8s-app: {{ .Release.Name }}
     type: agent
     version: v1
+  {{- if .Values.agent.daemonsetAnnotations }}
+  annotations:
+  {{ toYaml .Values.agent.daemonsetAnnotations | trim | indent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     k8s-app: {{ .Release.Name }}
     type: lapi
     version: v1
+  {{- if .Values.lapi.deployAnnotations }}
+  annotations:
+  {{ toYaml .Values.lapi.deployAnnotations | trim | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.lapi.replicas }}
   selector:

--- a/charts/crowdsec/templates/tls/agent-certificate.yaml
+++ b/charts/crowdsec/templates/tls/agent-certificate.yaml
@@ -18,6 +18,13 @@ spec:
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ join "," .Values.tls.agent.reflector.namespaces }}
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
       {{ end }}
+      {{ if .Values.tls.certManager.secretTemplate.annotations }}
+      {{ toYaml .Values.tls.certManager.secretTemplate.annotations | nindent 6 }}
+      {{ end }}
+    {{ if .Values.tls.certManager.secretTemplate.labels }}
+    labels:
+    {{ toYaml .Values.tls.certManager.secretTemplate.labels | nindent 6 }}
+    {{ end }}
   issuerRef:
     {{ if .Values.tls.certManager.issuerRef }}
     name: {{ .Values.tls.certManager.issuerRef.name }}

--- a/charts/crowdsec/templates/tls/bouncer-certificate.yaml
+++ b/charts/crowdsec/templates/tls/bouncer-certificate.yaml
@@ -18,6 +18,13 @@ spec:
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ join "," .Values.tls.bouncer.reflector.namespaces }}
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
       {{ end }}
+      {{ if .Values.tls.certManager.secretTemplate.annotations }}
+      {{ toYaml .Values.tls.certManager.secretTemplate.annotations | nindent 6 }}
+      {{ end }}
+    {{ if .Values.tls.certManager.secretTemplate.labels }}
+    labels:
+    {{ toYaml .Values.tls.certManager.secretTemplate.labels | nindent 6 }}
+    {{ end }}
   issuerRef:
     {{ if .Values.tls.certManager.issuerRef }}
     name: {{ .Values.tls.certManager.issuerRef.name }}

--- a/charts/crowdsec/templates/tls/lapi-certificate.yaml
+++ b/charts/crowdsec/templates/tls/lapi-certificate.yaml
@@ -21,4 +21,15 @@ spec:
     {{ else }}
     name: {{ .Release.Name }}-ca-issuer
     {{ end }}
+  {{ if or .Values.tls.certManager.secretTemplate.annotations .Values.tls.certManager.secretTemplate.labels }}
+  secretTemplate:
+    {{ if .Values.tls.certManager.secretTemplate.annotations }}
+    annotations:
+    {{ toYaml .Values.tls.certManager.secretTemplate.annotations | nindent 6 }}
+    {{ end }}
+    {{ if .Values.tls.certManager.secretTemplate.labels }}
+    labels:
+    {{ toYaml .Values.tls.certManager.secretTemplate.labels | nindent 6 }}
+    {{ end }}
+  {{ end }}
 {{ end }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -113,6 +113,10 @@ tls:
     issuerRef: {}
       # name: ""
       # kind: "ClusterIssuer"
+    # -- Add annotations and/or labels to generated secret
+    secretTemplate:
+      annotations: {}
+      labels: {}
     # -- duration for Certificate resources
     duration: 2160h # 90d
     # -- renewBefore for Certificate resources
@@ -165,6 +169,9 @@ lapi:
 
   # -- pod priority class name
   priorityClassName: ""
+
+  # -- Annotations to be added to lapi deployment
+  deployAnnotations: {}
 
   # -- Annotations to be added to lapi pods, if global podAnnotations are not set
   podAnnotations: {}
@@ -309,6 +316,9 @@ agent:
 
   # -- pod priority class name
   priorityClassName: ""
+
+  # -- Annotations to be added to agent daemonset
+  daemonsetAnnotations: {}
 
   # -- Annotations to be added to agent pods, if global podAnnotations are not set
   podAnnotations: {}


### PR DESCRIPTION
Add values to configure ```secretTemplate``` of ```certificate``` resources. Also add ```annotations``` to ```deployment``` and ```daemonset``` for lapi and agent.
This is required to add specific annotations for [Reloader](https://github.com/stakater/Reloader), which is a tool providing a workaround for #133, by triggering a rollout when it detects a secret change.

/kind enhancement
/area configuration