### PR TITLE
Add option to disable varlog hostPath

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -166,9 +166,11 @@ spec:
           - name: acquis-config-volume
             mountPath: {{ $crowdsecConfig }}/acquis.yaml
             subPath: acquis.yaml
+          {{- if .Values.agent.hostVarLog }}
           - name: varlog
             mountPath: /var/log
             readOnly: true
+          {{- end }}
           {{- if (eq "docker" .Values.container_runtime) }}
           - name: varlibdockercontainers
             mountPath: /var/lib/docker/containers
@@ -183,9 +185,11 @@ spec:
       - name: acquis-config-volume
         configMap:
           name: acquis-configmap
+      {{- if .Values.agent.hostVarLog }}
       - name: varlog
         hostPath:
           path: /var/log
+      {{- end }}
       {{- if .Values.agent.persistentVolume.config.enabled }}
       - name: crowdsec-agent-config
         persistentVolumeClaim:

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -333,6 +333,8 @@ agent:
       storageClassName: ""
       existingClaim: ""
       size: 100Mi
+  # -- Enable hostPath to /var/log
+  hostVarLog: true
   # -- environment variables from crowdsecurity/crowdsec docker image
   env: []
     # by default we configure the docker-logs parser to be able to parse docker logs in k8s


### PR DESCRIPTION
On a Kubernetes distribution like [Talos](https://www.talos.dev), a `hostPath` can cause issue with pod security.

Example of the agent DaemonSet :
```
Events:
  Type     Reason            Age                    From                  Message
  ----     ------            ----                   ----                  -------
  Warning  FailedCreate      57m                    daemonset-controller  Error creating: pods "crowdsec-agent-9x8ww" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      41m                    daemonset-controller  Error creating: pods "crowdsec-agent-jv295" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-j9rc8" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-4f4s7" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-zqlgx" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-tzwq5" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-j6478" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-vs8gf" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-4hsd4" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-bmqg6" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
  Warning  FailedCreate      24m                    daemonset-controller  Error creating: pods "crowdsec-agent-kt9vs" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers")
```

If I change the `container_runtime` to `containerd`, this remove `varlibdockercontainers`, but I can't disable `varlog`.

This PR add a new value to enable or not the `varlog` volume (enable by default).