### PR TITLE
Middleware API Version traefik.io/v1alpha1

### DIFF
--- a/charts/crowdsec-traefik-bouncer/templates/middleware.yaml
+++ b/charts/crowdsec-traefik-bouncer/templates/middleware.yaml
@@ -1,7 +1,7 @@
 # vim: set ft=gotmpl:
 ---
 
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ .Release.Name }}


### PR DESCRIPTION
Old traefik crds are deprecated and with traefik v3 not used anymore, so upgrade middleware api to traefik.io/v1alpha1