### PR TITLE
Add annotations to trigger restart when configmap or secret changes

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -20,13 +20,16 @@ spec:
       type: agent
   template:
     metadata:
-      {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | trim | indent 8 }}
-      {{- else if .Values.agent.podAnnotations }}
-      annotations:
-{{ toYaml .Values.agent.podAnnotations | trim | indent 8 }}
-      {{- end }}
+        checksum/agent-secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/agent-configmap: {{ include (print $.Template.BasePath "/agent-configmap.yaml") . | sha256sum }}
+        checksum/acquis-configmap: {{ include (print $.Template.BasePath "/acquis-configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | trim | indent 8 }}
+        {{- end }}
+        {{- if .Values.agent.podAnnotations }}
+        {{- toYaml .Values.agent.podAnnotations | trim | indent 8 }}
+        {{- end }}
       labels:
         k8s-app: {{ .Release.Name }}
         type: agent

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -22,13 +22,16 @@ spec:
   strategy: {{- toYaml .Values.lapi.strategy | nindent 4 }}
   template:
     metadata:
-      {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | trim | indent 8 }}
-      {{- else if .Values.lapi.podAnnotations }}
-      annotations:
-{{ toYaml .Values.lapi.podAnnotations | trim | indent 8 }}
-      {{- end }}
+        checksum/agent-secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/lapi-secret: {{ include (print $.Template.BasePath "/lapi-secrets.yaml") . | sha256sum }}
+        checksum/lapi-configmap: {{ include (print $.Template.BasePath "/lapi-configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | trim | indent 8 }}
+        {{- end }}
+        {{- if .Values.lapi.podAnnotations }}
+        {{- toYaml .Values.lapi.podAnnotations | trim | indent 8 }}
+        {{- end }}
       labels:
         k8s-app: {{ .Release.Name }}
         type: lapi


### PR DESCRIPTION
Add a checksum annotation of Configmaps and Secrets to pods, so it trigger a restart when one of them changes.

Also, there is an issue, when both ```podAnnotations``` and ```lapi.podAnnotations``` are both set, only ```podAnnotation``` is  used, and the other is ignored (because of a else if). Same issue for the agent.
This PR fixes it, by adding both when they both are defined.