### PR TITLE
enhance: Mark traefik helm chart as deprecated

### DIFF
--- a/charts/crowdsec-traefik-bouncer/Chart.yaml
+++ b/charts/crowdsec-traefik-bouncer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec-traefik-bouncer/Chart.yaml
+++ b/charts/crowdsec-traefik-bouncer/Chart.yaml
@@ -22,3 +22,5 @@ version: 0.1.3
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.5.0"
+
+deprecated: true


### PR DESCRIPTION
Mark traefik bouncer as deprecated by helm chart this will:

- Mark deprecation within helm chart
- Docs generation will add a note that chart is deprecated
- Anyone using the chart when updating will inform them this is now deprecated