### PR TITLE
[Fix] indentation for deploy, ds and pod annotations

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -11,7 +11,7 @@ metadata:
     version: v1
   {{- if .Values.agent.daemonsetAnnotations }}
   annotations:
-  {{ toYaml .Values.agent.daemonsetAnnotations | trim | indent 4 }}
+{{ toYaml .Values.agent.daemonsetAnnotations | trim | indent 4 }}
   {{- end }}
 spec:
   selector:
@@ -25,10 +25,10 @@ spec:
         checksum/agent-configmap: {{ include (print $.Template.BasePath "/agent-configmap.yaml") . | sha256sum }}
         checksum/acquis-configmap: {{ include (print $.Template.BasePath "/acquis-configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
-        {{- toYaml .Values.podAnnotations | trim | indent 8 }}
+{{ toYaml .Values.podAnnotations | trim | indent 8 }}
         {{- end }}
         {{- if .Values.agent.podAnnotations }}
-        {{- toYaml .Values.agent.podAnnotations | trim | indent 8 }}
+{{ toYaml .Values.agent.podAnnotations | trim | indent 8 }}
         {{- end }}
       labels:
         k8s-app: {{ .Release.Name }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     version: v1
   {{- if .Values.lapi.deployAnnotations }}
   annotations:
-  {{ toYaml .Values.lapi.deployAnnotations | trim | indent 4 }}
+{{ toYaml .Values.lapi.deployAnnotations | trim | indent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.lapi.replicas }}
@@ -27,10 +27,10 @@ spec:
         checksum/lapi-secret: {{ include (print $.Template.BasePath "/lapi-secrets.yaml") . | sha256sum }}
         checksum/lapi-configmap: {{ include (print $.Template.BasePath "/lapi-configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
-        {{- toYaml .Values.podAnnotations | trim | indent 8 }}
+{{ toYaml .Values.podAnnotations | trim | indent 8 }}
         {{- end }}
         {{- if .Values.lapi.podAnnotations }}
-        {{- toYaml .Values.lapi.podAnnotations | trim | indent 8 }}
+{{ toYaml .Values.lapi.podAnnotations | trim | indent 8 }}
         {{- end }}
       labels:
         k8s-app: {{ .Release.Name }}


### PR DESCRIPTION
Fix issue introduced by myself in #179, which I fixed in local but forgot to push, sorry about that.
Setting ```podAnnotations``` or ```lapi.podAnnotations```  break the manifest because of a bad indentation and ```{{-```, so it produce something like this:

values.yaml
```
podAnnotations:
  allPods: test

agent:
  daemonsetAnnotations:
    agentDs: test
  podAnnotations:
    agentPod: test
  acquisition:
    - namespace: ingress-nginx
      podName: ingress-nginx-controller-*
      program: nginx

lapi:
  deployAnnotations:
    lapiDeploy: test
  podAnnotations:
    lapiPod: test
```
result
```
[...]
spec:
  template:
    metadata:
      annotations:
        checksum/agent-secret: 33b575d4037387fc40a4e87bf644d8ef410d911d42cf9ac5c16c81f6f9208cd7
        checksum/lapi-secret: 6a759b5ae3a48ec705b7af68a0947c9e286ccae6d02a73f922e32d0fe88bfc4c
        checksum/lapi-configmap: f1c5b812195242564e3d57e5d84245ceb46d079f41fa31843ec56f51d011b77e        allPods: test        lapiPod: test
[...]
```

Sorry again about that issue.