### PR TITLE
Add values to add extraVolumes to lapi and agent

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -206,6 +206,9 @@ spec:
           - name: crowdsec-agent-tls
             mountPath: /etc/ssl/crowdsec-agent
           {{- end }}
+          {{- if .Values.agent.extraVolumeMounts }}
+          {{ toYaml .Values.agent.extraVolumeMounts | nindent 10 }}
+          {{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: acquis-config-volume
@@ -277,6 +280,9 @@ spec:
       - name: crowdsec-agent-tls
         secret:
           secretName: {{ .Release.Name }}-agent-tls
+      {{- end }}
+      {{- if .Values.agent.extraVolumes }}
+      {{ toYaml .Values.agent.extraVolumes | nindent 6 }}
       {{- end }}
       {{- with .Values.agent.nodeSelector }}
       nodeSelector:

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -192,7 +192,7 @@ spec:
         lifecycle:
           {{- toYaml .Values.lapi.lifecycle | nindent 10 }}
         {{- end }}
-        {{- if or (.Values.tls.enabled) (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) }}
+        {{- if or (.Values.tls.enabled) (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) (.Values.lapi.extraVolumeMounts) }}
         volumeMounts:
           {{- if .Values.tls.enabled }}
           - name: crowdsec-lapi-tls
@@ -239,6 +239,9 @@ spec:
             subPath: {{ $fileName }}
           {{- end }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.lapi.extraVolumeMounts }}
+          {{ toYaml .Values.lapi.extraVolumeMounts | nindent 10 }}
           {{- end }}
           {{- end }}
       {{- if .Values.lapi.dashboard.enabled }}
@@ -306,7 +309,7 @@ spec:
 
       {{- end }}
       terminationGracePeriodSeconds: 30
-      {{- if or (.Values.tls.enabled) (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) }}
+      {{- if or (.Values.tls.enabled) (.Values.lapi.persistentVolume.data.enabled) (.Values.lapi.persistentVolume.config.enabled) (.Values.lapi.dashboard.enabled) (include "lapiCustomConfigIsNotEmpty" .) (.Values.lapi.extraVolumes) }}
       volumes:
       {{- if .Values.lapi.persistentVolume.data.enabled }}
       - name: crowdsec-db
@@ -368,6 +371,9 @@ spec:
       - name: crowdsec-agent-tls
         secret:
           secretName: {{ .Release.Name }}-agent-tls
+      {{- end }}
+      {{- if .Values.lapi.extraVolumes }}
+      {{ toYaml .Values.lapi.extraVolumes | nindent 6 }}
       {{- end }}
       {{- end }}
       {{- with .Values.lapi.tolerations }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -182,6 +182,12 @@ lapi:
   # -- Extra init containers to be added to lapi pods
   extraInitContainers: []
 
+  # -- Extra volumes to be added to lapi pods
+  extraVolumes: []
+
+  # -- Extra volumeMounts to be added to lapi pods
+  extraVolumeMounts: []
+
   # -- resources for lapi
   resources:
     limits:
@@ -332,6 +338,12 @@ agent:
 
   # -- Extra init containers to be added to agent pods
   extraInitContainers: []
+
+  # -- Extra volumes to be added to agent pods
+  extraVolumes: []
+
+  # -- Extra volumeMounts to be added to agent pods
+  extraVolumeMounts: []
 
   resources:
     limits:


### PR DESCRIPTION
Add values to add extraVolumes and extraVolumeMounts to lapi and agent pods.
I only need ```lapi.extraVolumes``` for an initContainer, but I figured it's easy to add these for both the agent and lapi, which could come handy for someone else.

Tested with the following values:
```
agent:
  acquisition:
    - namespace: ingress-nginx
      podName: ingress-nginx-controller-*
      program: nginx
  extraVolumes:
    - name: agent-vol
      configMap:
        name: custom-agent-cm
  extraVolumeMounts:
    - name: agent-vol
      mountPath: /tmp/agent-vol

lapi:
  # Set persistence to false to test the condition adding volumes and volumeMounts (these are the only volumes and volumeMounts for lapi with default values)
  persistentVolume:
    data:
      enabled: false
    config:
      enabled: false
  extraVolumes:
    - name: lapi-vol
      configMap:
        name: custom-lapi-cm
  extraVolumeMounts:
    - name: lapi-vol
      mountPath: /tmp/lapi-vol
```

/kind enhancement
/area configuration