### PR TITLE
Fix registrationToken regenerated every time helm template is executed

### DIFF
--- a/charts/crowdsec/templates/_helpers.tpl
+++ b/charts/crowdsec/templates/_helpers.tpl
@@ -16,6 +16,20 @@ Generate CS_LAPI_SECRET if not specified in values
 {{- end -}}
 
 {{/*
+Generate REGISTRATION_TOKEN if not specified in values
+*/}}
+{{ define "lapi.registrationToken" }}
+{{- if .Values.lapi.secrets.registrationToken }}
+  {{- .Values.lapi.secrets.registrationToken -}}
+{{- else if (lookup "v1" "Secret" .Release.Namespace "crowdsec-lapi-secrets").data }}
+  {{- $obj := (lookup "v1" "Secret" .Release.Namespace "crowdsec-lapi-secrets").data -}}
+  {{- index $obj "registrationToken" | b64dec -}}
+{{- else -}}
+  {{- randAlphaNum 48 | b64enc -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
   notifications parameters check
 */}}
 {{ define "notificationsIsNotEmpty" }}

--- a/charts/crowdsec/templates/lapi-secrets.yaml
+++ b/charts/crowdsec/templates/lapi-secrets.yaml
@@ -12,7 +12,7 @@ metadata:
 type: Opaque
 data:
   csLapiSecret: {{ include "lapi.csLapiSecret" . | b64enc }}
-  registrationToken: {{ randAlphaNum 48 | b64enc }}
+  registrationToken: {{ include "lapi.registrationToken" . | b64enc }}
   {{- with .Values.lapi.extraSecrets }}
   {{- range $key, $value := . }}
   {{ $key }}: {{ $value | b64enc }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -300,6 +300,8 @@ lapi:
   secrets:
     # -- Shared LAPI secret. Will be generated randomly if not specified. Size must be > 64 characters
     csLapiSecret: ""
+    # -- LAPI registration token. Will be generated randomly if not specified.
+    registrationToken: ""
   # -- Any extra secrets you may need (for example, external DB password)
   extraSecrets: {}
     # dbPassword: randomPass


### PR DESCRIPTION
registrationToken added recently is always generated with helm, which can cause issue with some other tools using helm template, such as ArgoCD.

This PR is a small fix so the secret can be:
- explicitly defined in values
- retrieved from the secret, if already existing in the cluster
- generated by helm (default)

This is similar to what's already done for other secrets in this chart (csLapiSecret).

/kind fix
/area local-api