### PR TITLE
fix(crowdsec): Prevent empty annotation error for cert manifests

### DIFF
--- a/charts/crowdsec/templates/tls/agent-certificate.yaml
+++ b/charts/crowdsec/templates/tls/agent-certificate.yaml
@@ -12,6 +12,7 @@ spec:
   duration: {{ .Values.tls.certManager.duration }}
   renewBefore: {{ .Values.tls.certManager.renewBefore }}
   secretTemplate:
+    {{ if or .Values.tls.agent.reflector.namespaces .Values.tls.certManager.secretTemplate.annotations }}
     annotations:
       {{ if .Values.tls.agent.reflector.namespaces }}
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
@@ -21,6 +22,7 @@ spec:
       {{ if .Values.tls.certManager.secretTemplate.annotations }}
       {{ toYaml .Values.tls.certManager.secretTemplate.annotations | nindent 6 }}
       {{ end }}
+    {{ end }}
     {{ if .Values.tls.certManager.secretTemplate.labels }}
     labels:
     {{ toYaml .Values.tls.certManager.secretTemplate.labels | nindent 6 }}

--- a/charts/crowdsec/templates/tls/bouncer-certificate.yaml
+++ b/charts/crowdsec/templates/tls/bouncer-certificate.yaml
@@ -12,6 +12,7 @@ spec:
   duration: {{ .Values.tls.certManager.duration }}
   renewBefore: {{ .Values.tls.certManager.renewBefore }}
   secretTemplate:
+    {{ if or .Values.tls.agent.reflector.namespaces .Values.tls.certManager.secretTemplate.annotations }}
     annotations:
       {{ if .Values.tls.bouncer.reflector.namespaces }}
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
@@ -21,6 +22,7 @@ spec:
       {{ if .Values.tls.certManager.secretTemplate.annotations }}
       {{ toYaml .Values.tls.certManager.secretTemplate.annotations | nindent 6 }}
       {{ end }}
+    {{ end }}
     {{ if .Values.tls.certManager.secretTemplate.labels }}
     labels:
     {{ toYaml .Values.tls.certManager.secretTemplate.labels | nindent 6 }}


### PR DESCRIPTION
## Problem

When using a values file like the following ([taken from this crowdsec blog post](https://www.crowdsec.net/blog/integrating-crowdsec-kubernetes-tls)):

```
container_runtime: containerd
tls:
  enabled: true
  bouncer:
    reflector:
      namespaces: ["traefik"]
agent:
  # Specify each pod whose logs you want to process
  acquisition:
    - namespace: traefik
      podName: traefik-*
      program: traefik
  env:
    - name: PARSERS
      value: "crowdsecurity/cri-logs"
    - name: COLLECTIONS
      value: "crowdsecurity/traefik"
    - name: DISABLE_PARSERS
      value: "crowdsecurity/whitelists"
  persistentVolume:
    config:
      enabled: false
lapi:
  dashboard:
    enabled: false
    ingress:
      host: my-crowdsec.lan
      enabled: true
  persistentVolume:
    config:
      enabled: false
  env:
    - name: DISABLE_ONLINE_API
      value: "true"
```

The following error is observed:

```
Could not determine release state: unable to determine cluster state: Certificate/crowdsec/crowdsec-agent dry-run failed (Invalid): Certificate.cert-manager.io "crowdsec-agent" is invalid: spec.secretTemplate.annotations: Invalid value: "null": spec.secretTemplate.annotations in body must be of type object: "null"
```

This is because the annotations key is set empty in the 
 agent-certificate and bouncer-certificate resource files.

 ## Proposed Solution

 Implement similar logic that exists in the lapi-certificate template file, meaning only add the `annotations` key if we'll be populating it.