### PR TITLE
Activate auto registration token by default and update docs on authentication

### DIFF
--- a/charts/crowdsec/README.md.gotmpl
+++ b/charts/crowdsec/README.md.gotmpl
@@ -53,6 +53,7 @@ config:
           token: "${REGISTRATION_TOKEN}" # /!\ Do not modify this variable (auto-generated and handled by the chart)
           allowed_ranges: # /!\ Make sure to adapt to the pod IP ranges used by your cluster
             - "127.0.0.1/32"
+            - "192.168.0.0/16"
             - "10.0.0.0/8"
             - "172.16.0.0/12"
 ```

--- a/charts/crowdsec/README.md.gotmpl
+++ b/charts/crowdsec/README.md.gotmpl
@@ -32,9 +32,64 @@ helm install crowdsec crowdsec/crowdsec -f crowdsec-values.yaml -n crowdsec
 helm delete crowdsec -n crowdsec
 ```
 
-## Setup for High Availability
+## Authentication
 
-Below a basic configuration for High availability
+This charts support two types of authentication between the agents / appsec pods and the LAPI: an auto registration token and TLS client authentication.
+
+### Auto registration token
+
+By default, this chart makes use of an auto registration token completely handled by the chart.
+This is setup with the following part in the `values.yaml` file. Make sure to adapt to the pod IP ranges used by your cluster. 
+
+Also, when you modify the `config.config.yaml.local` entry in your own `values.yaml` make sure to put this piece in it as well.
+
+```
+config:
+  config.yaml.local: |
+    api:
+      server:
+        auto_registration: # Activate if not using TLS for authentication
+          enabled: true
+          token: "${REGISTRATION_TOKEN}" # /!\ Do not modify this variable (auto-generated and handled by the chart)
+          allowed_ranges: # /!\ Make sure to adapt to the pod IP ranges used by your cluster
+            - "127.0.0.1/32"
+            - "10.0.0.0/8"
+            - "172.16.0.0/12"
+```
+
+### TLS client authentication
+
+Currently TLS authentication is only possible between the agent and the LAPI as appsec doesn't support HTTPS yet.
+The below configuration will activate TLS on the LAPI and TLS client authentication for the agent. 
+Certificates are renewed by default with [cert-manager](https://github.com/cert-manager/cert-manager).
+
+```
+tls:
+  enabled: true
+  agent:
+    tlsClientAuth: true
+```
+
+### Cleaning of stale agents / appsec registration in the LAPI
+
+Both methods add a machine per pod in the LAPI. These aren't automatically cleaned and the list of machines can become large over time.
+Crowdsec offers a [flush option](https://docs.crowdsec.net/docs/next/configuration/crowdsec_configuration/#flush) to clean them up. 
+Add the `flush:` part to your `db_config`.
+
+```
+config:
+  config.yaml.local: |
+    db_config:
+      flush:
+        agents_autodelete:
+          cert: 60m # This is TLS client authentication
+          login_password: 60m # This includes the auto registration token as well
+        ## Flush both login types if the machine has not logged in for 60 minutes or more
+```
+
+## Setup for LAPI High Availability
+
+Below a basic configuration for high availability of the LAPI
 
 ```
 # your-values.yaml
@@ -94,20 +149,6 @@ appsec:
   env:
     - name: COLLECTIONS
       value: "crowdsecurity/appsec-virtual-patching"
-
-# This allows the LAPI pod to register and communicate with the appsec pod
-config:
-  config.yaml.local: |
-    api:
-      server:
-        auto_registration:
-          enabled: true
-          token: "${REGISTRATION_TOKEN}" # /!\ Do not modify this variable (auto-generated and handled by the chart)
-          allowed_ranges:
-            - "127.0.0.1/32"
-            - "192.168.0.0/16"
-            - "10.0.0.0/8"
-            - "172.16.0.0/12"
 ```
 
 Or you can also use your own custom configurations and rules for AppSec:
@@ -136,25 +177,11 @@ appsec:
   env:
     - name: COLLECTIONS
       value: "crowdsecurity/appsec-virtual-patching crowdsecurity/appsec-crs"
-
-# This allows the LAPI pod to register and communicate with the appsec pod
-config:
-  config.yaml.local: |
-    api:
-      server:
-        auto_registration:
-          enabled: true
-          token: "${REGISTRATION_TOKEN}" # /!\ Do not modify this variable (auto-generated and handled by the chart)
-          allowed_ranges:
-            - "127.0.0.1/32"
-            - "192.168.0.0/16"
-            - "10.0.0.0/8"
-            - "172.16.0.0/12"
 ```
 
 ### With Traefik
 
-In the traefik `values.yaml`, you need to add the following configuration:
+In the Traefik `values.yaml`, you need to add the following configuration:
 
 ```
 # traefik-values.yaml
@@ -190,7 +217,7 @@ spec:
       crowdsecLapiKey: "<YOUR_BOUNCER_KEY>"
 ```
 
-### With Ingrees Nginx
+### With Nginx
 
 Following [this documentation](https://docs.crowdsec.net/u/bouncers/ingress-nginx).
 

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -81,18 +81,16 @@ config:
     #    - Alert.Remediation == true && Alert.GetScope() == "Ip"
     #  ...
   # -- General configuration (https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#configuration-example)
-  config.yaml.local: ""
-    #   |
-    # api:
-    #   server:
-    #     auto_registration: # Activate if not using TLS for authentication or when using Appsec
-    #       enabled: true
-    #       token: "${REGISTRATION_TOKEN}" # /!\ Do not modify this variable (auto-generated and handled by the chart)
-    #       allowed_ranges:
-    #         - "127.0.0.1/32"
-    #         - "192.168.0.0/16"
-    #         - "10.0.0.0/8"
-    #         - "172.16.0.0/12"
+  config.yaml.local: |
+    api:
+      server:
+        auto_registration: # Activate if not using TLS for authentication
+          enabled: true
+          token: "${REGISTRATION_TOKEN}" # /!\ Do not modify this variable (auto-generated and handled by the chart)
+          allowed_ranges: # /!\ Make sure to adapt to the pod IP ranges used by your cluster
+            - "127.0.0.1/32"
+            - "10.0.0.0/8"
+            - "172.16.0.0/12"
     # db_config:
     #   type:     postgresql
     #   user:     crowdsec

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -89,6 +89,7 @@ config:
           token: "${REGISTRATION_TOKEN}" # /!\ Do not modify this variable (auto-generated and handled by the chart)
           allowed_ranges: # /!\ Make sure to adapt to the pod IP ranges used by your cluster
             - "127.0.0.1/32"
+            - "192.168.0.0/16"
             - "10.0.0.0/8"
             - "172.16.0.0/12"
     # db_config:


### PR DESCRIPTION
- Activated auto registration by default so the charts works with the default `values.yaml` (fix for #228)
- Added documentation on authentication, including auto registration, TLS client authentication and flushing old machines (fix for #230)
- Removed auto registration token from Appsec documentation (moved into authentication)
- Fixed a few typos 