### PR TITLE
fix(crowdsec): Create capi-credentials secrets in pre-upgrade

### DIFF
--- a/charts/crowdsec/templates/capi-credentials-secrets.yaml
+++ b/charts/crowdsec/templates/capi-credentials-secrets.yaml
@@ -10,7 +10,7 @@ metadata:
     type: capi-credentials-job
     version: v1
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-1"
     "helm.sh/resource-policy": "keep"
 type: Opaque


### PR DESCRIPTION
Hello!

It seems that there is an issue with the new central API register job.

The job is created as a pre-install and a pre-upgrade helm hook, and requires the capi-credentials secret to exist.
But this secret is only created as a pre-install helm hook.

So for a new install it works perfectly, but if you upgrade an existing helm release then the register job will be stuck as it cannot find its secret.

This PR should solve the issue.