### PR TITLE
feat(capi-register-job): add custom label to CAPI register job

### DIFF
--- a/charts/crowdsec/templates/capi-register-job.yaml
+++ b/charts/crowdsec/templates/capi-register-job.yaml
@@ -9,6 +9,9 @@ metadata:
     k8s-app: {{ .Release.Name }}
     type: capi-register-job
     version: v1
+    {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 4 }}
+    {{- end }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded


### PR DESCRIPTION
Hello !

I created this PR to add the ability to customize the labels of the capi-register-job job.

In our project we use labels to redirect application logs to different ElasticSearch indexes.

/kind feature
/area configuration