### PR TITLE
feat(capi-register-job): add custom labels to CAPI register pod

### DIFF
--- a/charts/crowdsec/templates/capi-register-job.yaml
+++ b/charts/crowdsec/templates/capi-register-job.yaml
@@ -18,6 +18,14 @@ metadata:
     "helm.sh/hook-weight": "0"
 spec:
   template:
+    metadata:
+      labels:
+        k8s-app: {{ .Release.Name }}
+        type: capi-register-job
+        version: v1
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-configmap-updater-sa
       restartPolicy: OnFailure


### PR DESCRIPTION
Hello !

I created this PR to add the ability to customize the labels of the capi-register pod.

In our project we use labels to redirect application logs to different ElasticSearch indexes.

/kind feature
/area configuration