### PR TITLE
Added generated release notes to release workflow

### DIFF
--- a/cr.yaml
+++ b/cr.yaml
@@ -1,2 +1,3 @@
 owner: crowdsecurity
 git-base-url: https://api.github.com/
+generate-release-notes: true


### PR DESCRIPTION
Enables release note generation via an option provided by chart-releaser. chart-releaser uses GitHub's feature for automatic release note generation (https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). 

This makes it easier to detect the changes a new release brings. 