### PR TITLE
Support re-using LAPI credentials in Agent and AppSec

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -53,7 +53,36 @@ spec:
       - name: wait-for-lapi-and-register
         image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ['sh', '-c', 'until nc "$LAPI_HOST" "$LAPI_PORT" -z; do echo waiting for lapi to start; sleep 5; done; ln -s /staging/etc/crowdsec /etc/crowdsec && cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN" && cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml']
+        command:
+          - sh
+          - "-c"
+          - |
+            until nc "$LAPI_HOST" "$LAPI_PORT" -z; do
+              echo waiting for lapi to start
+              sleep 5
+            done
+
+            ln -s /staging/etc/crowdsec /etc/crowdsec
+
+            if test -f /tmp_config/local_api_credentials.yaml
+            then
+              cp /tmp_config/local_api_credentials.yaml /etc/crowdsec/local_api_credentials.yaml
+
+              cscli lapi status &>/dev/null
+              val=$?
+
+              if test $val -eq 0
+              then
+                echo "Credentials found and valid"
+                exit 0
+              else
+                echo "Credentials found but not valid, trying re-register"
+              fi
+            fi
+
+            set -e
+            cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN"
+            cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml
       {{- else }}
       - name: wait-for-lapi
         image: "{{ .Values.agent.wait_for_lapi.image.repository }}:{{ .Values.agent.wait_for_lapi.image.tag }}"

--- a/charts/crowdsec/templates/agent-deployment.yaml
+++ b/charts/crowdsec/templates/agent-deployment.yaml
@@ -55,7 +55,36 @@ spec:
       - name: wait-for-lapi-and-register
         image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ['sh', '-c', 'until nc "$LAPI_HOST" "$LAPI_PORT" -z; do echo waiting for lapi to start; sleep 5; done; ln -s /staging/etc/crowdsec /etc/crowdsec && cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN" && cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml']
+        command:
+          - sh
+          - "-c"
+          - |
+            until nc "$LAPI_HOST" "$LAPI_PORT" -z; do
+              echo waiting for lapi to start
+              sleep 5
+            done
+
+            ln -s /staging/etc/crowdsec /etc/crowdsec
+
+            if test -f /tmp_config/local_api_credentials.yaml
+            then
+              cp /tmp_config/local_api_credentials.yaml /etc/crowdsec/local_api_credentials.yaml
+
+              cscli lapi status &>/dev/null
+              val=$?
+
+              if test $val -eq 0
+              then
+                echo "Credentials found and valid"
+                exit 0
+              else
+                echo "Credentials found but not valid, trying re-register"
+              fi
+            fi
+
+            set -e
+            cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN"
+            cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml
       {{- else }}
       - name: wait-for-lapi
         image: "{{ .Values.agent.wait_for_lapi.image.repository }}:{{ .Values.agent.wait_for_lapi.image.tag }}"

--- a/charts/crowdsec/templates/appsec-deployment.yaml
+++ b/charts/crowdsec/templates/appsec-deployment.yaml
@@ -55,7 +55,36 @@ spec:
       - name: wait-for-lapi-and-register
         image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ['sh', '-c', 'until nc "$LAPI_HOST" "$LAPI_PORT" -z; do echo waiting for lapi to start; sleep 5; done; ln -s /staging/etc/crowdsec /etc/crowdsec && cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN" && cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml']
+        command:
+          - sh
+          - "-c"
+          - |
+            until nc "$LAPI_HOST" "$LAPI_PORT" -z; do
+              echo waiting for lapi to start
+              sleep 5
+            done
+
+            ln -s /staging/etc/crowdsec /etc/crowdsec
+
+            if test -f /tmp_config/local_api_credentials.yaml
+            then
+              cp /tmp_config/local_api_credentials.yaml /etc/crowdsec/local_api_credentials.yaml
+
+              cscli lapi status &>/dev/null
+              val=$?
+
+              if test $val -eq 0
+              then
+                echo "Credentials found and valid"
+                exit 0
+              else
+                echo "Credentials found but not valid, trying re-register"
+              fi
+            fi
+
+            set -e
+            cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN"
+            cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml
       {{- else }}
       - name: wait-for-lapi
         image: "{{ .Values.appsec.wait_for_lapi.image.repository }}:{{ .Values.appsec.wait_for_lapi.image.tag }}"


### PR DESCRIPTION
Check beforehand if tmp dir contains the config file and try to re-use it

Fixes: #252

/kind enhancement
/area configuration