### PR TITLE
Fixed incorrect placement of imagePullSecrets in capi-register-job

### DIFF
--- a/charts/crowdsec/templates/capi-register-job.yaml
+++ b/charts/crowdsec/templates/capi-register-job.yaml
@@ -29,13 +29,13 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}-configmap-updater-sa
       restartPolicy: OnFailure
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
       containers:
         - name: capi-register
-          {{- if .Values.image.pullSecrets }}
-          imagePullSecrets:
-{{ toYaml .Values.image.pullSecrets | indent 12 }}
-          {{- end }}
-          image: "crowdsecurity/crowdsec:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "/bin/bash"


### PR DESCRIPTION
- Fixed incorrect placement of imagePullSecrets (was under container, now under pod spec).
- Made container image in capi-register-job configurable via .Values.image.repository and .Values.image.tag.