### PR TITLE
bump v1.6.9, chart bump

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.3
+version: 0.19.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.6.8
+appVersion: v1.6.9


### PR DESCRIPTION
This CrowdSec version includes the option to set agents to self delete instead of waiting for flush timer

You can achieve this by configuring inside the values.yaml: **(note the example shown is an extension of the default values)**

```yaml
config:
  config.yaml.local: |
    api:
      client:
        unregister_on_exit: true ## false means either no delete or wait for flush timer
      server:
        auto_registration: # Activate if not using TLS for authentication
          enabled: true
          token: "${REGISTRATION_TOKEN}" # /!\ Do not modify this variable (auto-generated and handled by the chart)
          allowed_ranges: # /!\ Make sure to adapt to the pod IP ranges used by your cluster
            - "127.0.0.1/32"
            - "192.168.0.0/16"
            - "10.0.0.0/8"
            - "172.16.0.0/12"
```