### PR TITLE
set securityContext's from values

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -64,8 +64,7 @@ spec:
             cpu: 1m
             memory: 10Mi
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
+          {{- toYaml .Values.agent.wait_for_lapi.securityContext | nindent 10 }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}
         volumeMounts:
           - name: crowdsec-config
@@ -168,8 +167,7 @@ spec:
         {{ end }}
 
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
+          {{- toYaml .Values.agent.securityContext | nindent 10 }}
 
         volumeMounts:
           {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}

--- a/charts/crowdsec/templates/agent-deployment.yaml
+++ b/charts/crowdsec/templates/agent-deployment.yaml
@@ -66,8 +66,7 @@ spec:
             cpu: 1m
             memory: 10Mi
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
+          {{- toYaml .Values.agent.wait_for_lapi.securityContext | nindent 10 }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}
         volumeMounts:
           - name: crowdsec-config
@@ -171,8 +170,7 @@ spec:
         {{ end }}
 
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
+          {{- toYaml .Values.agent.securityContext | nindent 10 }}
 
         volumeMounts:
           {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}

--- a/charts/crowdsec/templates/appsec-deployment.yaml
+++ b/charts/crowdsec/templates/appsec-deployment.yaml
@@ -69,8 +69,7 @@ spec:
             cpu: 1m
             memory: 10Mi
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
+          {{- toYaml .Values.appsec.wai_for_lapi.securityContext | nindent 10 }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.appsec.tlsClientAuth) }}
         volumeMounts:
           - name: crowdsec-config
@@ -179,8 +178,7 @@ spec:
         {{ end }}
 
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
+          {{- toYaml .Values.appsec.securityContext | nindent 10 }}
 
         volumeMounts:
           - name: crowdsec-config

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -171,8 +171,7 @@ spec:
             {{- end }}
 
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
+          {{- toYaml .Values.lapi.securityContext | nindent 10 }}
 
         ports:
           - name: lapi
@@ -307,8 +306,7 @@ spec:
           timeoutSeconds: 1
 
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
+          {{- toYaml .Values.lapi.dashboard.securityContext | nindent 10 }}
 
         {{- with .Values.lapi.dashboard.resources }}
         resources:

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -238,6 +238,11 @@ lapi:
   # -- Extra volumeMounts to be added to lapi pods
   extraVolumeMounts: []
 
+  # -- Container securityContext
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+
   # -- resources for lapi
   resources:
     limits:
@@ -272,6 +277,11 @@ lapi:
       # requests:
       #   cpu: 500m
       #   memory: 1Gi
+
+    # -- Container securityContext
+    securityContext:
+      allowPrivilegeEscalation: false
+      privileged: false
 
     # -- Enable ingress object
     ingress:
@@ -431,6 +441,11 @@ agent:
   # -- Extra volumeMounts to be added to agent pods
   extraVolumeMounts: []
 
+  # -- Container securityContext
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+
   resources:
     limits:
       memory: 250Mi
@@ -564,6 +579,10 @@ agent:
       pullPolicy: IfNotPresent
       # -- docker image tag
       tag: "1.28"
+    # -- Container securityContext
+    securityContext:
+      allowPrivilegeEscalation: false
+      privileged: false
 
 # -- Enable AppSec (https://docs.crowdsec.net/docs/next/appsec/intro)
 appsec:
@@ -639,6 +658,10 @@ appsec:
   extraVolumes: []
   # -- Extra volumeMounts to be added to appsec pods
   extraVolumeMounts: []
+  # -- Container securityContext
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
   # -- resources for appsec pods
   resources:
     limits:
@@ -741,3 +764,7 @@ appsec:
       pullPolicy: IfNotPresent
       # -- docker image tag
       tag: "1.28"
+    # -- Container securityContext
+    securityContext:
+      allowPrivilegeEscalation: false
+      privileged: false


### PR DESCRIPTION
I actually needed #90 , but since it hasn't had any activity since over a year, and is making multiple changes (that IMHO should be split into different PR's) at once, I've created this simple change that gives users the flexibility to overwrite the `securityContext` definitions, while at the same time not breaking any existing deployments.