### PR TITLE
move chart release action to manual workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,6 @@
 name: Release Charts
 
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - "charts/**/values.yaml"
-      - "charts/**/README.md" # ensure section exists; regen when touched
-      - ".github/workflows/release.yaml"
-      - "charts/**/Chart.yaml"
-  # Adjust if your chart lives elsewhere
+on: workflow_dispatch
 env:
   CHART_DIR: charts/crowdsec
 
@@ -45,8 +36,6 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           message: "chore(charts): regenerate README.md"
-          branch: main
-
   release:
     needs: update-readme
     permissions:
@@ -75,7 +64,7 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
-          
+
       - if: ${{ steps.cr.outputs.changed_charts }}
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Previously, each time anything was pushed to main, chart-releaser would attempt to create a new release, and skip it if it was already existing.

While not optimal, this was mostly fine, as the job was basically a noop if nothing changed. But since #310 was merged, the job is now also pushing to the github container registry, which means that the last tag created was continuously updated, which is very misleading to users (and this force to have an always-clean main branch, which we don't usually guarantee).

To resolve this, change the release workflow to be a manual-only workflow. While this requires an additional step on release, this is likely less dangerous overall as we will control exactly when release will be created.