### PR TITLE
Allow Agent Daemonset Update Strategy

### DIFF
--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -505,7 +505,7 @@ controller:
 | `agent.lapiHost`                                 | Host of the LAPI for the agent to connect to                                               | `""`    |
 | `agent.lapiPort`                                 | Port of the LAPI for the agent to connect to                                               | `8080`  |
 | `agent.replicas`                                 | Number of replicas when deploying as a Deployment                                          | `1`     |
-| `agent.strategy`                                 | Deployment strategy when `isDeployment` is true                                            | `{}`    |
+| `agent.strategy`                                 | Update strategy for the agent workload (applies to Deployment or DaemonSet)                | `{}`    |
 | `agent.ports`                                    | Custom container ports to expose (default: metrics port 6060 if enabled)                   | `[]`    |
 | `agent.additionalAcquisition`                    | Extra log acquisition sources (see https://docs.crowdsec.net/docs/next/data_sources/intro) | `[]`    |
 | `agent.acquisition`                              | Pod log acquisition definitions (namespace, podName, program, etc.)                        | `[]`    |

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -12,6 +12,9 @@ metadata:
 {{ toYaml .Values.agent.daemonsetAnnotations | trim | indent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.agent.daemonsetStrategy }}
+  updateStrategy: {{- toYaml .Values.agent.daemonsetStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       k8s-app: {{ .Release.Name }}

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -12,8 +12,8 @@ metadata:
 {{ toYaml .Values.agent.daemonsetAnnotations | trim | indent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.agent.daemonsetStrategy }}
-  updateStrategy: {{- toYaml .Values.agent.daemonsetStrategy | nindent 4 }}
+  {{- if .Values.agent.strategy }}
+  updateStrategy: {{- toYaml .Values.agent.strategy | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/crowdsec/templates/agent-deployment.yaml
+++ b/charts/crowdsec/templates/agent-deployment.yaml
@@ -12,8 +12,10 @@ metadata:
 {{ toYaml .Values.agent.deploymentAnnotations | trim | indent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.agent.deploymentStrategy }}
+  strategy: {{- toYaml .Values.agent.deploymentStrategy | nindent 4 }}
+  {{- end }}
   replicas: {{ .Values.agent.replicas }}
-  strategy: {{- toYaml .Values.agent.strategy | nindent 4 }}
   selector:
     matchLabels:
       k8s-app: {{ .Release.Name }}

--- a/charts/crowdsec/templates/agent-deployment.yaml
+++ b/charts/crowdsec/templates/agent-deployment.yaml
@@ -12,8 +12,8 @@ metadata:
 {{ toYaml .Values.agent.deploymentAnnotations | trim | indent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.agent.deploymentStrategy }}
-  strategy: {{- toYaml .Values.agent.deploymentStrategy | nindent 4 }}
+  {{- if .Values.agent.strategy }}
+  strategy: {{- toYaml .Values.agent.strategy | nindent 4 }}
   {{- end }}
   replicas: {{ .Values.agent.replicas }}
   selector:

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -467,10 +467,16 @@ agent:
   # -- replicas for agent if isDeployment is set to true
   ## @param agent.replicas Number of replicas when deploying as a Deployment
   replicas: 1
-  # -- strategy for agent if isDeployment is set to true
-  ## @param agent.strategy [object] Deployment strategy when `isDeployment` is true
-  strategy:
+  # -- strategy for agent deployment updates if isDeployment is set to true
+  ## @param agent.deploymentStrategy [object] Update strategy for the agent Deployment when `isDeployment` is true
+  deploymentStrategy:
     type: Recreate
+  # -- strategy for agent daemonset updates
+  ## @param agent.daemonsetStrategy [object] Update strategy for the agent DaemonSet
+  daemonsetStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
 
   # -- add your custom ports here, by default we expose port 6060 for metrics if metrics is enabled
   ## @param agent.ports [array] Custom container ports to expose (default: metrics port 6060 if enabled)

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -467,16 +467,10 @@ agent:
   # -- replicas for agent if isDeployment is set to true
   ## @param agent.replicas Number of replicas when deploying as a Deployment
   replicas: 1
-  # -- strategy for agent deployment updates if isDeployment is set to true
-  ## @param agent.deploymentStrategy [object] Update strategy for the agent Deployment when `isDeployment` is true
-  deploymentStrategy:
+  # -- update strategy for agent (applies to either Deployment or DaemonSet based on isDeployment)
+  ## @param agent.strategy [object] Update strategy for the agent workload
+  strategy:
     type: Recreate
-  # -- strategy for agent daemonset updates
-  ## @param agent.daemonsetStrategy [object] Update strategy for the agent DaemonSet
-  daemonsetStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 25%
 
   # -- add your custom ports here, by default we expose port 6060 for metrics if metrics is enabled
   ## @param agent.ports [array] Custom container ports to expose (default: metrics port 6060 if enabled)


### PR DESCRIPTION
Noticed this wasn't fleshed out and we could use it.

AI Slop generated by devstral2 and curated by a moron

/kind enhancement
/area agent