### PR TITLE
Add image variants, PDB/updateStrategy, feature.yaml and optional acquisition container selection

### DIFF
--- a/charts/crowdsec/README.md
+++ b/charts/crowdsec/README.md
@@ -373,17 +373,19 @@ controller:
 
 ### Image
 
-| Name                       | Description                                                                                                        | Value                    |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------ |
-| `image.repository`         | [string] docker image repository name                                                                              | `crowdsecurity/crowdsec` |
-| `image.pullPolicy`         | [string] Image pull policy (Always, IfNotPresent, Never)                                                           | `IfNotPresent`           |
-| `image.pullSecrets`        | Image pull secrets (array of objects with a 'name' field)                                                          | `[]`                     |
-| `image.tag`                | docker image tag (empty defaults to chart AppVersion)                                                              | `""`                     |
-| `image.kubectl.repository` | [string] kubectl image repository used by registration jobs initContainers                                         | `alpine/kubectl`         |
-| `image.kubectl.tag`        | [string] kubectl image tag (override to match your cluster version if you encounter issues with registration jobs) | `latest`                 |
-| `image.kubectl.pullPolicy` | [string] kubectl image pull policy (Always, IfNotPresent, Never)                                                   | `IfNotPresent`           |
-| `podAnnotations`           | podAnnotations to be added to pods (string:string map)                                                             | `{}`                     |
-| `podLabels`                | Labels to be added to pods (string:string map)                                                                     | `{}`                     |
+| Name                       | Description                                                                                                                                                                                                                                      | Value                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| `image.repository`         | [string] docker image repository name                                                                                                                                                                                                            | `crowdsecurity/crowdsec` |
+| `image.pullPolicy`         | [string] Image pull policy (Always, IfNotPresent, Never)                                                                                                                                                                                         | `IfNotPresent`           |
+| `image.pullSecrets`        | Image pull secrets (array of objects with a 'name' field)                                                                                                                                                                                        | `[]`                     |
+| `image.tag`                | docker image tag (empty defaults to chart AppVersion)                                                                                                                                                                                            | `""`                     |
+| `image.tagSuffix`          | Suffix appended to the image tag. E.g. set to "-debian" to use crowdsec:v1.6.0-debian                                                                                                                                                            | `""`                     |
+| `image.kubectl.repository` | [string] kubectl image repository used by registration jobs initContainers                                                                                                                                                                       | `alpine/kubectl`         |
+| `image.kubectl.tag`        | [string] kubectl image tag (override to match your cluster version if you encounter issues with registration jobs)                                                                                                                               | `latest`                 |
+| `image.kubectl.pullPolicy` | [string] kubectl image pull policy (Always, IfNotPresent, Never)                                                                                                                                                                                 | `IfNotPresent`           |
+| `image.jobs.tagSuffix`     | Suffix appended to the image tag for registration jobs. When null (default), inherits from image.tagSuffix. Set to "" to use the Alpine-based image when image.tagSuffix is "-debian" (jobs use apk and are incompatible with the Debian image). | `nil`                    |
+| `podAnnotations`           | podAnnotations to be added to pods (string:string map)                                                                                                                                                                                           | `{}`                     |
+| `podLabels`                | Labels to be added to pods (string:string map)                                                                                                                                                                                                   | `{}`                     |
 
 ### Configuration
 
@@ -403,6 +405,7 @@ controller:
 | `config.notifications`                       | notification on alert configuration                                                                                                 | `{}`    |
 | `config.agent_config.yaml.local`             | This configuration file is merged with agent pod main configuration file                                                            | `""`    |
 | `config.appsec_config.yaml.local`            | This configuration file is merged with appsec pod main configuration file                                                           | `""`    |
+| `config.feature.yaml`                        | Feature flags to enable or disable experimental CrowdSec features                                                                   | `""`    |
 | `tls.enabled`                                | Is tls enabled ?                                                                                                                    | `false` |
 | `tls.caBundle`                               | pem format CA collection                                                                                                            | `true`  |
 | `tls.insecureSkipVerify`                     |                                                                                                                                     | `false` |
@@ -436,160 +439,164 @@ controller:
 
 ### lapi
 
-| Name                                            | Description                                                                                                               | Value               |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `lapi.enabled`                                  | Enable LAPI deployment (enabled by default)                                                                               | `true`              |
-| `lapi.replicas`                                 | Number of replicas for the Local API                                                                                      | `1`                 |
-| `lapi.env`                                      | Extra environment variables passed to the crowdsecurity/crowdsec container                                                | `[]`                |
-| `lapi.envFrom`                                  | Environment variables loaded from Kubernetes Secrets or ConfigMaps                                                        | `[]`                |
-| `lapi.ingress.enabled`                          | Enable ingress for the LAPI service                                                                                       | `false`             |
-| `lapi.ingress.annotations`                      | Annotations to apply to the LAPI ingress object                                                                           | `{}`                |
-| `lapi.ingress.ingressClassName`                 | IngressClass name for the LAPI ingress                                                                                    | `""`                |
-| `lapi.ingress.host`                             | Hostname for the LAPI ingress                                                                                             | `""`                |
-| `lapi.priorityClassName`                        | Pod priority class name                                                                                                   | `""`                |
-| `lapi.deployAnnotations`                        | Annotations applied to the LAPI Deployment                                                                                | `{}`                |
-| `lapi.podAnnotations`                           | Annotations applied to LAPI pods                                                                                          | `{}`                |
-| `lapi.podLabels`                                | Labels applied to LAPI pods                                                                                               | `{}`                |
-| `lapi.extraInitContainers`                      | Additional init containers for LAPI pods                                                                                  | `[]`                |
-| `lapi.extraVolumes`                             | Additional volumes for LAPI pods                                                                                          | `[]`                |
-| `lapi.extraVolumeMounts`                        | Additional volumeMounts for LAPI pods                                                                                     | `[]`                |
-| `lapi.podSecurityContext`                       | Security context for LAPI pods                                                                                            | `{}`                |
-| `lapi.securityContext`                          | Security context for the LAPI contaienr                                                                                   | `{}`                |
-| `lapi.resources`                                | Resource requests and limits for the LAPI pods                                                                            | `{}`                |
-| `lapi.persistentVolume.data.enabled`            | Enable persistent volume for the data folder (stores bouncer API keys)                                                    | `true`              |
-| `lapi.persistentVolume.data.accessModes`        | Access modes for the data PVC                                                                                             | `["ReadWriteOnce"]` |
-| `lapi.persistentVolume.data.storageClassName`   | StorageClass name for the data PVC                                                                                        | `""`                |
-| `lapi.persistentVolume.data.existingClaim`      | Existing PersistentVolumeClaim to use for the data PVC                                                                    | `""`                |
-| `lapi.persistentVolume.data.subPath`            | subPath to use within the volume                                                                                          | `""`                |
-| `lapi.persistentVolume.data.size`               | Requested size for the data PVC                                                                                           | `""`                |
-| `lapi.persistentVolume.config.enabled`          | Enable persistent volume for the config folder (stores API credentials)                                                   | `true`              |
-| `lapi.persistentVolume.config.accessModes`      | Access modes for the config PVC                                                                                           | `["ReadWriteOnce"]` |
-| `lapi.persistentVolume.config.storageClassName` | StorageClass name for the config PVC                                                                                      | `""`                |
-| `lapi.persistentVolume.config.existingClaim`    | Existing PersistentVolumeClaim to use for the config PVC                                                                  | `""`                |
-| `lapi.persistentVolume.config.subPath`          | subPath to use within the volume                                                                                          | `""`                |
-| `lapi.persistentVolume.config.size`             | Requested size for the config PVC                                                                                         | `""`                |
-| `lapi.service`                                  | Configuration of kubernetes lapi service                                                                                  | `{}`                |
-| `lapi.service.type`                             | Kubernetes service type for LAPI                                                                                          | `""`                |
-| `lapi.service.labels`                           | Extra labels to add to the LAPI service                                                                                   | `{}`                |
-| `lapi.service.annotations`                      | Extra annotations to add to the LAPI service                                                                              | `{}`                |
-| `lapi.service.externalIPs`                      | List of external IPs for the LAPI service                                                                                 | `[]`                |
-| `lapi.service.loadBalancerIP`                   | Specific loadBalancer IP for the LAPI service                                                                             | `nil`               |
-| `lapi.service.loadBalancerClass`                | LoadBalancer class for the LAPI service                                                                                   | `nil`               |
-| `lapi.service.externalTrafficPolicy`            | External traffic policy for the LAPI service                                                                              | `""`                |
-| `lapi.nodeSelector`                             | Node selector for scheduling LAPI pods                                                                                    | `{}`                |
-| `lapi.tolerations`                              | Tolerations for scheduling LAPI pods                                                                                      | `[]`                |
-| `lapi.dnsConfig`                                | DNS configuration for LAPI pods                                                                                           | `{}`                |
-| `lapi.affinity`                                 | Affinity rules for LAPI pods                                                                                              | `{}`                |
-| `lapi.topologySpreadConstraints`                | Topology spread constraints for LAPI pods                                                                                 | `[]`                |
-| `lapi.metrics.enabled`                          | Enable service monitoring for Prometheus (exposes port 6060)                                                              | `true`              |
-| `lapi.metrics.serviceMonitor.enabled`           | [object] Create a ServiceMonitor resource for Prometheus                                                                  | `true`              |
-| `lapi.metrics.serviceMonitor.additionalLabels`  | Extra labels for the ServiceMonitor                                                                                       | `{}`                |
-| `lapi.metrics.podMonitor.enabled`               | Enables prometheus operator podMonitor                                                                                    | `false`             |
-| `lapi.metrics.podMonitor.additionalLabels`      | additional labels for podMonitor                                                                                          | `{}`                |
-| `lapi.strategy.type`                            | Deployment strategy for the LAPI deployment                                                                               | `""`                |
-| `lapi.secrets.csLapiSecret`                     | Shared LAPI secret (randomly generated if not specified, must be >64 chars)                                               | `""`                |
-| `lapi.secrets.registrationToken`                | Registration token for AppSec (randomly generated if not specified, must be >48 chars)                                    | `""`                |
-| `lapi.extraSecrets`                             | Additional secrets to inject (e.g., external DB password)                                                                 | `{}`                |
-| `lapi.lifecycle`                                | Lifecycle hooks for LAPI pods (postStart, preStop, etc.)                                                                  | `{}`                |
-| `lapi.storeCAPICredentialsInSecret`             | [object] Store Central API credentials in a Secret (required if LAPI replicas > 1)                                        | `false`             |
-| `lapi.storeLAPICscliCredentialsInSecret`        | [object] Store LAPI cscli credentials in a Secret. Useful if LAPI replicas > 1 or to setup LAPI with a persistent volume. | `false`             |
+| Name                                            | Description                                                                                                                | Value               |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `lapi.enabled`                                  | Enable LAPI deployment (enabled by default)                                                                                | `true`              |
+| `lapi.replicas`                                 | Number of replicas for the Local API                                                                                       | `1`                 |
+| `lapi.env`                                      | Extra environment variables passed to the crowdsecurity/crowdsec container                                                 | `[]`                |
+| `lapi.envFrom`                                  | Environment variables loaded from Kubernetes Secrets or ConfigMaps                                                         | `[]`                |
+| `lapi.ingress.enabled`                          | Enable ingress for the LAPI service                                                                                        | `false`             |
+| `lapi.ingress.annotations`                      | Annotations to apply to the LAPI ingress object                                                                            | `{}`                |
+| `lapi.ingress.ingressClassName`                 | IngressClass name for the LAPI ingress                                                                                     | `""`                |
+| `lapi.ingress.host`                             | Hostname for the LAPI ingress                                                                                              | `""`                |
+| `lapi.priorityClassName`                        | Pod priority class name                                                                                                    | `""`                |
+| `lapi.deployAnnotations`                        | Annotations applied to the LAPI Deployment                                                                                 | `{}`                |
+| `lapi.podAnnotations`                           | Annotations applied to LAPI pods                                                                                           | `{}`                |
+| `lapi.podLabels`                                | Labels applied to LAPI pods                                                                                                | `{}`                |
+| `lapi.extraInitContainers`                      | Additional init containers for LAPI pods                                                                                   | `[]`                |
+| `lapi.extraVolumes`                             | Additional volumes for LAPI pods                                                                                           | `[]`                |
+| `lapi.extraVolumeMounts`                        | Additional volumeMounts for LAPI pods                                                                                      | `[]`                |
+| `lapi.podSecurityContext`                       | Security context for LAPI pods                                                                                             | `{}`                |
+| `lapi.securityContext`                          | Security context for the LAPI contaienr                                                                                    | `{}`                |
+| `lapi.resources`                                | Resource requests and limits for the LAPI pods                                                                             | `{}`                |
+| `lapi.persistentVolume.data.enabled`            | Enable persistent volume for the data folder (stores bouncer API keys)                                                     | `true`              |
+| `lapi.persistentVolume.data.accessModes`        | Access modes for the data PVC                                                                                              | `["ReadWriteOnce"]` |
+| `lapi.persistentVolume.data.storageClassName`   | StorageClass name for the data PVC                                                                                         | `""`                |
+| `lapi.persistentVolume.data.existingClaim`      | Existing PersistentVolumeClaim to use for the data PVC                                                                     | `""`                |
+| `lapi.persistentVolume.data.subPath`            | subPath to use within the volume                                                                                           | `""`                |
+| `lapi.persistentVolume.data.size`               | Requested size for the data PVC                                                                                            | `""`                |
+| `lapi.persistentVolume.config.enabled`          | Enable persistent volume for the config folder (stores API credentials)                                                    | `true`              |
+| `lapi.persistentVolume.config.accessModes`      | Access modes for the config PVC                                                                                            | `["ReadWriteOnce"]` |
+| `lapi.persistentVolume.config.storageClassName` | StorageClass name for the config PVC                                                                                       | `""`                |
+| `lapi.persistentVolume.config.existingClaim`    | Existing PersistentVolumeClaim to use for the config PVC                                                                   | `""`                |
+| `lapi.persistentVolume.config.subPath`          | subPath to use within the volume                                                                                           | `""`                |
+| `lapi.persistentVolume.config.size`             | Requested size for the config PVC                                                                                          | `""`                |
+| `lapi.service`                                  | Configuration of kubernetes lapi service                                                                                   | `{}`                |
+| `lapi.service.type`                             | Kubernetes service type for LAPI                                                                                           | `""`                |
+| `lapi.service.labels`                           | Extra labels to add to the LAPI service                                                                                    | `{}`                |
+| `lapi.service.annotations`                      | Extra annotations to add to the LAPI service                                                                               | `{}`                |
+| `lapi.service.externalIPs`                      | List of external IPs for the LAPI service                                                                                  | `[]`                |
+| `lapi.service.loadBalancerIP`                   | Specific loadBalancer IP for the LAPI service                                                                              | `nil`               |
+| `lapi.service.loadBalancerClass`                | LoadBalancer class for the LAPI service                                                                                    | `nil`               |
+| `lapi.service.externalTrafficPolicy`            | External traffic policy for the LAPI service                                                                               | `""`                |
+| `lapi.nodeSelector`                             | Node selector for scheduling LAPI pods                                                                                     | `{}`                |
+| `lapi.tolerations`                              | Tolerations for scheduling LAPI pods                                                                                       | `[]`                |
+| `lapi.dnsConfig`                                | DNS configuration for LAPI pods                                                                                            | `{}`                |
+| `lapi.affinity`                                 | Affinity rules for LAPI pods                                                                                               | `{}`                |
+| `lapi.topologySpreadConstraints`                | Topology spread constraints for LAPI pods                                                                                  | `[]`                |
+| `lapi.metrics.enabled`                          | Enable service monitoring for Prometheus (exposes port 6060)                                                               | `true`              |
+| `lapi.metrics.serviceMonitor.enabled`           | [object] Create a ServiceMonitor resource for Prometheus                                                                   | `true`              |
+| `lapi.metrics.serviceMonitor.additionalLabels`  | Extra labels for the ServiceMonitor                                                                                        | `{}`                |
+| `lapi.metrics.podMonitor.enabled`               | Enables prometheus operator podMonitor                                                                                     | `false`             |
+| `lapi.metrics.podMonitor.additionalLabels`      | additional labels for podMonitor                                                                                           | `{}`                |
+| `lapi.strategy.type`                            | Deployment strategy for the LAPI deployment                                                                                | `""`                |
+| `lapi.secrets.csLapiSecret`                     | Shared LAPI secret (randomly generated if not specified, must be >64 chars)                                                | `""`                |
+| `lapi.secrets.registrationToken`                | Registration token for AppSec (randomly generated if not specified, must be >48 chars)                                     | `""`                |
+| `lapi.extraSecrets`                             | Additional secrets to inject (e.g., external DB password)                                                                  | `{}`                |
+| `lapi.lifecycle`                                | Lifecycle hooks for LAPI pods (postStart, preStop, etc.)                                                                   | `{}`                |
+| `lapi.storeCAPICredentialsInSecret`             | [object] Store Central API credentials in a Secret (required if LAPI replicas > 1)                                         | `false`             |
+| `lapi.storeLAPICscliCredentialsInSecret`        | [object] Store LAPI cscli credentials in a Secret. Useful if LAPI replicas > 1 or to setup LAPI with a persistent volume.  | `false`             |
+| `lapi.podDisruptionBudget.enabled`              | Enable PodDisruptionBudget for LAPI pods                                                                                   | `false`             |
+| `lapi.podDisruptionBudget.minAvailable`         | Minimum number of available LAPI pods during voluntary disruptions. Use either minAvailable or maxUnavailable, not both.   | `1`                 |
+| `lapi.podDisruptionBudget.maxUnavailable`       | Maximum number of unavailable LAPI pods during voluntary disruptions. Use either minAvailable or maxUnavailable, not both. | `nil`               |
 
 ### agent
 
-| Name                                             | Description                                                                                | Value   |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------ | ------- |
-| `agent.enabled`                                  | [object] Enable CrowdSec agent (enabled by default)                                        | `true`  |
-| `agent.isDeployment`                             | [object] Deploy agent as a Deployment instead of a DaemonSet                               | `false` |
-| `agent.serviceAccountName`                       | Service account name for the agent pods                                                    | `""`    |
-| `agent.lapiURL`                                  | URL of the LAPI for the agent to connect to (defaults to internal service URL)             | `""`    |
-| `agent.lapiHost`                                 | Host of the LAPI for the agent to connect to                                               | `""`    |
-| `agent.lapiPort`                                 | Port of the LAPI for the agent to connect to                                               | `8080`  |
-| `agent.replicas`                                 | Number of replicas when deploying as a Deployment                                          | `1`     |
-| `agent.strategy`                                 | Deployment strategy when `isDeployment` is true                                            | `{}`    |
-| `agent.ports`                                    | Custom container ports to expose (default: metrics port 6060 if enabled)                   | `[]`    |
-| `agent.additionalAcquisition`                    | Extra log acquisition sources (see https://docs.crowdsec.net/docs/next/data_sources/intro) | `[]`    |
-| `agent.acquisition`                              | Pod log acquisition definitions (namespace, podName, program, etc.)                        | `[]`    |
-| `agent.priorityClassName`                        | Priority class name for agent pods                                                         | `""`    |
-| `agent.daemonsetAnnotations`                     | Annotations applied to the agent DaemonSet                                                 | `{}`    |
-| `agent.deploymentAnnotations`                    | Annotations applied to the agent Deployment                                                | `{}`    |
-| `agent.podAnnotations`                           | Annotations applied to agent pods                                                          | `{}`    |
-| `agent.podLabels`                                | Labels applied to agent pods                                                               | `{}`    |
-| `agent.extraInitContainers`                      | Extra init containers for agent pods                                                       | `[]`    |
-| `agent.extraVolumes`                             | Extra volumes for agent pods                                                               | `[]`    |
-| `agent.extraVolumeMounts`                        | Extra volume mounts for agent pods                                                         | `[]`    |
-| `agent.podSecurityContext`                       | Security context for agent pods                                                            | `{}`    |
-| `agent.securityContext`                          | Security context for agent containers                                                      | `{}`    |
-| `agent.resources`                                | Resource requests and limits for agent pods                                                | `{}`    |
-| `agent.persistentVolume.config.enabled`          | [object] Enable persistent volume for agent config                                         | `false` |
-| `agent.persistentVolume.config.accessModes`      | Access modes for the config PVC                                                            | `[]`    |
-| `agent.persistentVolume.config.storageClassName` | StorageClass name for the config PVC                                                       | `""`    |
-| `agent.persistentVolume.config.existingClaim`    | Existing PVC name to use for config                                                        | `""`    |
-| `agent.persistentVolume.config.subPath`          | subPath to use within the volume                                                           | `""`    |
-| `agent.persistentVolume.config.size`             | Requested size for the config PVC                                                          | `""`    |
-| `agent.hostVarLog`                               | [object] Mount hostPath `/var/log` into the agent pod                                      | `true`  |
-| `agent.env`                                      | Environment variables passed to the crowdsecurity/crowdsec container                       | `[]`    |
-| `agent.nodeSelector`                             | Node selector for agent pods                                                               | `{}`    |
-| `agent.tolerations`                              | Tolerations for scheduling agent pods                                                      | `[]`    |
-| `agent.affinity`                                 | Affinity rules for agent pods                                                              | `{}`    |
-| `agent.livenessProbe`                            | Liveness probe configuration for agent pods                                                | `{}`    |
-| `agent.readinessProbe`                           | Readiness probe configuration for agent pods                                               | `{}`    |
-| `agent.startupProbe`                             | Startup probe configuration for agent pods                                                 | `{}`    |
-| `agent.metrics.enabled`                          | Enable service monitoring for Prometheus (exposes port 6060)                               | `true`  |
-| `agent.metrics.serviceMonitor.enabled`           | Create a ServiceMonitor resource for Prometheus                                            | `false` |
-| `agent.metrics.serviceMonitor.additionalLabels`  | Extra labels for the ServiceMonitor                                                        | `{}`    |
-| `agent.metrics.podMonitor.enabled`               | Create a PodMonitor resource for Prometheus                                                | `false` |
-| `agent.metrics.podMonitor.additionalLabels`      | Extra labels for the PodMonitor                                                            | `{}`    |
-| `agent.service.type`                             | Kubernetes Service type for agent                                                          | `""`    |
-| `agent.service.labels`                           | Labels applied to the agent Service                                                        | `{}`    |
-| `agent.service.annotations`                      | Annotations applied to the agent Service                                                   | `{}`    |
-| `agent.service.externalIPs`                      | External IPs assigned to the agent Service                                                 | `[]`    |
-| `agent.service.loadBalancerIP`                   | Fixed LoadBalancer IP for the agent Service                                                | `nil`   |
-| `agent.service.loadBalancerClass`                | LoadBalancer class for the agent Service                                                   | `nil`   |
-| `agent.service.externalTrafficPolicy`            | External traffic policy for the agent Service                                              | `""`    |
-| `agent.service.ports`                            | Custom service ports (default: metrics port 6060 if enabled)                               | `[]`    |
-| `agent.wait_for_lapi.image.repository`           | Repository for the wait-for-lapi init container image                                      | `""`    |
-| `agent.wait_for_lapi.image.pullPolicy`           | Image pull policy for the wait-for-lapi init container                                     | `""`    |
-| `agent.wait_for_lapi.image.tag`                  | Image tag for the wait-for-lapi init container                                             | `""`    |
-| `agent.wait_for_lapi.securityContext`            | Security context for the wait-for-lapi init container                                      | `{}`    |
-| `appsec.enabled`                                 | [object] Enable AppSec component (disabled by default)                                     | `false` |
-| `appsec.lapiURL`                                 | URL the AppSec component uses to reach LAPI (defaults to internal service URL)             | `""`    |
-| `appsec.lapiHost`                                | Hostname the AppSec component uses to reach LAPI                                           | `""`    |
-| `appsec.lapiPort`                                | Port the AppSec component uses to reach LAPI                                               | `8080`  |
-| `appsec.replicas`                                | Number of replicas for the AppSec Deployment                                               | `1`     |
-| `appsec.strategy`                                | Deployment strategy for AppSec                                                             | `{}`    |
-| `appsec.acquisitions`                            | AppSec acquisitions (datasource listeners), e.g. appsec listener on 7422                   | `[]`    |
-| `appsec.configs`                                 | AppSec configs (key = filename, value = file content)                                      | `{}`    |
-| `appsec.rules`                                   | AppSec rule files (key = filename, value = file content)                                   | `{}`    |
-| `appsec.priorityClassName`                       | Priority class name for AppSec pods                                                        | `""`    |
-| `appsec.deployAnnotations`                       | Annotations added to the AppSec Deployment                                                 | `{}`    |
-| `appsec.podAnnotations`                          | Annotations added to AppSec pods                                                           | `{}`    |
-| `appsec.podLabels`                               | Labels added to AppSec pods                                                                | `{}`    |
-| `appsec.extraInitContainers`                     | Extra init containers for AppSec pods                                                      | `[]`    |
-| `appsec.extraVolumes`                            | Extra volumes for AppSec pods                                                              | `[]`    |
-| `appsec.extraVolumeMounts`                       | Extra volume mounts for AppSec pods                                                        | `[]`    |
-| `appsec.podSecurityContext`                      | Security context for AppSec pods                                                           | `{}`    |
-| `appsec.securityContext`                         | Security context for the appsec container                                                  | `{}`    |
-| `appsec.resources`                               | Resource requests and limits for AppSec pods                                               | `{}`    |
-| `appsec.env`                                     | Environment variables for the AppSec container (collections/configs/rules toggles, etc.)   | `[]`    |
-| `appsec.nodeSelector`                            | Node selector for scheduling AppSec pods                                                   | `{}`    |
-| `appsec.tolerations`                             | Tolerations for scheduling AppSec pods                                                     | `[]`    |
-| `appsec.affinity`                                | Affinity rules for scheduling AppSec pods                                                  | `{}`    |
-| `appsec.livenessProbe`                           | Liveness probe configuration for AppSec pods                                               | `{}`    |
-| `appsec.readinessProbe`                          | Readiness probe configuration for AppSec pods                                              | `{}`    |
-| `appsec.startupProbe`                            | Startup probe configuration for AppSec pods                                                | `{}`    |
-| `appsec.metrics.enabled`                         | Enable service monitoring (exposes metrics on 6060; AppSec listener typically 7422)        | `true`  |
-| `appsec.metrics.serviceMonitor.enabled`          | Create a ServiceMonitor for Prometheus scraping                                            | `false` |
-| `appsec.metrics.serviceMonitor.additionalLabels` | Extra labels for the ServiceMonitor                                                        | `{}`    |
-| `appsec.metrics.podMonitor.enabled`              | Create a PodMonitor for Prometheus scraping                                                | `false` |
-| `appsec.metrics.podMonitor.additionalLabels`     | Extra labels for the PodMonitor                                                            | `{}`    |
-| `appsec.service.type`                            | Kubernetes Service type for AppSec                                                         | `""`    |
-| `appsec.service.labels`                          | Additional labels for the AppSec Service                                                   | `{}`    |
-| `appsec.service.annotations`                     | Annotations to apply to the LAPI ingress object                                            | `{}`    |
-| `appsec.service.externalIPs`                     | External IPs for the AppSec Service                                                        | `[]`    |
-| `appsec.service.loadBalancerIP`                  | Fixed LoadBalancer IP for the AppSec Service                                               | `nil`   |
-| `appsec.service.loadBalancerClass`               | LoadBalancer class for the AppSec Service                                                  | `nil`   |
-| `appsec.service.externalTrafficPolicy`           | External traffic policy for the AppSec Service                                             | `""`    |
-| `appsec.wait_for_lapi.image.repository`          | Repository for the wait-for-lapi init con                                                  | `""`    |
-| `appsec.wait_for_lapi.image.pullPolicy`          | Image pull policy for the wait-for-lapi init container                                     | `""`    |
-| `appsec.wait_for_lapi.image.tag`                 | Image tag for the wait-for-lapi init container                                             | `1.28`  |
-| `appsec.wait_for_lapi.securityContext`           | Security context for the wait-for-lapi init container                                      | `{}`    |
+| Name                                             | Description                                                                                 | Value   |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------- | ------- |
+| `agent.enabled`                                  | [object] Enable CrowdSec agent (enabled by default)                                         | `true`  |
+| `agent.isDeployment`                             | [object] Deploy agent as a Deployment instead of a DaemonSet                                | `false` |
+| `agent.serviceAccountName`                       | Service account name for the agent pods                                                     | `""`    |
+| `agent.lapiURL`                                  | URL of the LAPI for the agent to connect to (defaults to internal service URL)              | `""`    |
+| `agent.lapiHost`                                 | Host of the LAPI for the agent to connect to                                                | `""`    |
+| `agent.lapiPort`                                 | Port of the LAPI for the agent to connect to                                                | `8080`  |
+| `agent.replicas`                                 | Number of replicas when deploying as a Deployment                                           | `1`     |
+| `agent.strategy`                                 | Deployment strategy when `isDeployment` is true                                             | `{}`    |
+| `agent.updateStrategy`                           | Update strategy for the agent DaemonSet (when isDeployment is false)                        | `{}`    |
+| `agent.ports`                                    | Custom container ports to expose (default: metrics port 6060 if enabled)                    | `[]`    |
+| `agent.additionalAcquisition`                    | Extra log acquisition sources (see https://docs.crowdsec.net/docs/next/data_sources/intro)  | `[]`    |
+| `agent.acquisition`                              | Pod log acquisition definitions (namespace, podName, optional containerName, program, etc.) | `[]`    |
+| `agent.priorityClassName`                        | Priority class name for agent pods                                                          | `""`    |
+| `agent.daemonsetAnnotations`                     | Annotations applied to the agent DaemonSet                                                  | `{}`    |
+| `agent.deploymentAnnotations`                    | Annotations applied to the agent Deployment                                                 | `{}`    |
+| `agent.podAnnotations`                           | Annotations applied to agent pods                                                           | `{}`    |
+| `agent.podLabels`                                | Labels applied to agent pods                                                                | `{}`    |
+| `agent.extraInitContainers`                      | Extra init containers for agent pods                                                        | `[]`    |
+| `agent.extraVolumes`                             | Extra volumes for agent pods                                                                | `[]`    |
+| `agent.extraVolumeMounts`                        | Extra volume mounts for agent pods                                                          | `[]`    |
+| `agent.podSecurityContext`                       | Security context for agent pods                                                             | `{}`    |
+| `agent.securityContext`                          | Security context for agent containers                                                       | `{}`    |
+| `agent.resources`                                | Resource requests and limits for agent pods                                                 | `{}`    |
+| `agent.persistentVolume.config.enabled`          | [object] Enable persistent volume for agent config                                          | `false` |
+| `agent.persistentVolume.config.accessModes`      | Access modes for the config PVC                                                             | `[]`    |
+| `agent.persistentVolume.config.storageClassName` | StorageClass name for the config PVC                                                        | `""`    |
+| `agent.persistentVolume.config.existingClaim`    | Existing PVC name to use for config                                                         | `""`    |
+| `agent.persistentVolume.config.subPath`          | subPath to use within the volume                                                            | `""`    |
+| `agent.persistentVolume.config.size`             | Requested size for the config PVC                                                           | `""`    |
+| `agent.hostVarLog`                               | [object] Mount hostPath `/var/log` into the agent pod                                       | `true`  |
+| `agent.env`                                      | Environment variables passed to the crowdsecurity/crowdsec container                        | `[]`    |
+| `agent.nodeSelector`                             | Node selector for agent pods                                                                | `{}`    |
+| `agent.tolerations`                              | Tolerations for scheduling agent pods                                                       | `[]`    |
+| `agent.affinity`                                 | Affinity rules for agent pods                                                               | `{}`    |
+| `agent.livenessProbe`                            | Liveness probe configuration for agent pods                                                 | `{}`    |
+| `agent.readinessProbe`                           | Readiness probe configuration for agent pods                                                | `{}`    |
+| `agent.startupProbe`                             | Startup probe configuration for agent pods                                                  | `{}`    |
+| `agent.metrics.enabled`                          | Enable service monitoring for Prometheus (exposes port 6060)                                | `true`  |
+| `agent.metrics.serviceMonitor.enabled`           | Create a ServiceMonitor resource for Prometheus                                             | `false` |
+| `agent.metrics.serviceMonitor.additionalLabels`  | Extra labels for the ServiceMonitor                                                         | `{}`    |
+| `agent.metrics.podMonitor.enabled`               | Create a PodMonitor resource for Prometheus                                                 | `false` |
+| `agent.metrics.podMonitor.additionalLabels`      | Extra labels for the PodMonitor                                                             | `{}`    |
+| `agent.service.type`                             | Kubernetes Service type for agent                                                           | `""`    |
+| `agent.service.labels`                           | Labels applied to the agent Service                                                         | `{}`    |
+| `agent.service.annotations`                      | Annotations applied to the agent Service                                                    | `{}`    |
+| `agent.service.externalIPs`                      | External IPs assigned to the agent Service                                                  | `[]`    |
+| `agent.service.loadBalancerIP`                   | Fixed LoadBalancer IP for the agent Service                                                 | `nil`   |
+| `agent.service.loadBalancerClass`                | LoadBalancer class for the agent Service                                                    | `nil`   |
+| `agent.service.externalTrafficPolicy`            | External traffic policy for the agent Service                                               | `""`    |
+| `agent.service.ports`                            | Custom service ports (default: metrics port 6060 if enabled)                                | `[]`    |
+| `agent.wait_for_lapi.image.repository`           | Repository for the wait-for-lapi init container image                                       | `""`    |
+| `agent.wait_for_lapi.image.pullPolicy`           | Image pull policy for the wait-for-lapi init container                                      | `""`    |
+| `agent.wait_for_lapi.image.tag`                  | Image tag for the wait-for-lapi init container                                              | `""`    |
+| `agent.wait_for_lapi.securityContext`            | Security context for the wait-for-lapi init container                                       | `{}`    |
+| `appsec.enabled`                                 | [object] Enable AppSec component (disabled by default)                                      | `false` |
+| `appsec.lapiURL`                                 | URL the AppSec component uses to reach LAPI (defaults to internal service URL)              | `""`    |
+| `appsec.lapiHost`                                | Hostname the AppSec component uses to reach LAPI                                            | `""`    |
+| `appsec.lapiPort`                                | Port the AppSec component uses to reach LAPI                                                | `8080`  |
+| `appsec.replicas`                                | Number of replicas for the AppSec Deployment                                                | `1`     |
+| `appsec.strategy`                                | Deployment strategy for AppSec                                                              | `{}`    |
+| `appsec.acquisitions`                            | AppSec acquisitions (datasource listeners), e.g. appsec listener on 7422                    | `[]`    |
+| `appsec.configs`                                 | AppSec configs (key = filename, value = file content)                                       | `{}`    |
+| `appsec.rules`                                   | AppSec rule files (key = filename, value = file content)                                    | `{}`    |
+| `appsec.priorityClassName`                       | Priority class name for AppSec pods                                                         | `""`    |
+| `appsec.deployAnnotations`                       | Annotations added to the AppSec Deployment                                                  | `{}`    |
+| `appsec.podAnnotations`                          | Annotations added to AppSec pods                                                            | `{}`    |
+| `appsec.podLabels`                               | Labels added to AppSec pods                                                                 | `{}`    |
+| `appsec.extraInitContainers`                     | Extra init containers for AppSec pods                                                       | `[]`    |
+| `appsec.extraVolumes`                            | Extra volumes for AppSec pods                                                               | `[]`    |
+| `appsec.extraVolumeMounts`                       | Extra volume mounts for AppSec pods                                                         | `[]`    |
+| `appsec.podSecurityContext`                      | Security context for AppSec pods                                                            | `{}`    |
+| `appsec.securityContext`                         | Security context for the appsec container                                                   | `{}`    |
+| `appsec.resources`                               | Resource requests and limits for AppSec pods                                                | `{}`    |
+| `appsec.env`                                     | Environment variables for the AppSec container (collections/configs/rules toggles, etc.)    | `[]`    |
+| `appsec.nodeSelector`                            | Node selector for scheduling AppSec pods                                                    | `{}`    |
+| `appsec.tolerations`                             | Tolerations for scheduling AppSec pods                                                      | `[]`    |
+| `appsec.affinity`                                | Affinity rules for scheduling AppSec pods                                                   | `{}`    |
+| `appsec.livenessProbe`                           | Liveness probe configuration for AppSec pods                                                | `{}`    |
+| `appsec.readinessProbe`                          | Readiness probe configuration for AppSec pods                                               | `{}`    |
+| `appsec.startupProbe`                            | Startup probe configuration for AppSec pods                                                 | `{}`    |
+| `appsec.metrics.enabled`                         | Enable service monitoring (exposes metrics on 6060; AppSec listener typically 7422)         | `true`  |
+| `appsec.metrics.serviceMonitor.enabled`          | Create a ServiceMonitor for Prometheus scraping                                             | `false` |
+| `appsec.metrics.serviceMonitor.additionalLabels` | Extra labels for the ServiceMonitor                                                         | `{}`    |
+| `appsec.metrics.podMonitor.enabled`              | Create a PodMonitor for Prometheus scraping                                                 | `false` |
+| `appsec.metrics.podMonitor.additionalLabels`     | Extra labels for the PodMonitor                                                             | `{}`    |
+| `appsec.service.type`                            | Kubernetes Service type for AppSec                                                          | `""`    |
+| `appsec.service.labels`                          | Additional labels for the AppSec Service                                                    | `{}`    |
+| `appsec.service.annotations`                     | Annotations to apply to the LAPI ingress object                                             | `{}`    |
+| `appsec.service.externalIPs`                     | External IPs for the AppSec Service                                                         | `[]`    |
+| `appsec.service.loadBalancerIP`                  | Fixed LoadBalancer IP for the AppSec Service                                                | `nil`   |
+| `appsec.service.loadBalancerClass`               | LoadBalancer class for the AppSec Service                                                   | `nil`   |
+| `appsec.service.externalTrafficPolicy`           | External traffic policy for the AppSec Service                                              | `""`    |
+| `appsec.wait_for_lapi.image.repository`          | Repository for the wait-for-lapi init con                                                   | `""`    |
+| `appsec.wait_for_lapi.image.pullPolicy`          | Image pull policy for the wait-for-lapi init container                                      | `""`    |
+| `appsec.wait_for_lapi.image.tag`                 | Image tag for the wait-for-lapi init container                                              | `1.28`  |
+| `appsec.wait_for_lapi.securityContext`           | Security context for the wait-for-lapi init container                                       | `{}`    |

--- a/charts/crowdsec/templates/_helpers.tpl
+++ b/charts/crowdsec/templates/_helpers.tpl
@@ -67,7 +67,7 @@ true
   lapi custom config check
 */}}
 {{ define "lapiCustomConfigIsNotEmpty" }}
-{{- if or (index .Values.config "profiles.yaml") (index .Values.config "config.yaml.local") ((include "notificationsIsNotEmpty" .)) }}
+{{- if or (index .Values.config "profiles.yaml") (index .Values.config "config.yaml.local") ((include "notificationsIsNotEmpty" .)) (index .Values.config "feature.yaml") }}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/crowdsec/templates/_helpers.tpl
+++ b/charts/crowdsec/templates/_helpers.tpl
@@ -95,6 +95,18 @@ true
 {{- end }}
 
 {{/*
+  Return the tag suffix to use for registration jobs images.
+  Falls back to image.tagSuffix when image.jobs.tagSuffix is null.
+*/}}
+{{- define "jobsImageTagSuffix" -}}
+{{- if kindIs "invalid" .Values.image.jobs.tagSuffix -}}
+{{- .Values.image.tagSuffix -}}
+{{- else -}}
+{{- .Values.image.jobs.tagSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
   Return the kubectl helper image used by registration jobs.
   If image.kubectl.tag is empty, default to latest.
 */}}

--- a/charts/crowdsec/templates/acquis-configmap.yaml
+++ b/charts/crowdsec/templates/acquis-configmap.yaml
@@ -10,7 +10,11 @@ data:
     {{- range .Values.agent.acquisition }}
     ---
     filenames:
+    {{- if .containerName }}
+      - /var/log/containers/{{ .podName }}_{{ .namespace }}_{{ .containerName }}-*.log
+    {{- else }}
       - /var/log/containers/{{ .podName }}_{{ .namespace }}_*.log
+    {{- end }}
     force_inotify: true
     poll_without_inotify: {{ .poll_without_inotify | default "false"}}
     labels:

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -16,6 +16,7 @@ spec:
     matchLabels:
       k8s-app: {{ .Release.Name }}
       type: agent
+  updateStrategy: {{- toYaml .Values.agent.updateStrategy | nindent 4 }}
   template:
     metadata:
       annotations:

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}
       - name: wait-for-lapi-and-register
-        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ['sh', '-c', 'until nc "$LAPI_HOST" "$LAPI_PORT" -z; do echo waiting for lapi to start; sleep 5; done; ln -s /staging/etc/crowdsec /etc/crowdsec && cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN" && cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml']
       {{- else }}
@@ -96,7 +96,7 @@ spec:
       {{- end }}
       containers:
       - name: crowdsec-agent
-        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
     {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}
       {{- if .Values.agent.persistentVolume.config.enabled }}

--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -248,6 +248,11 @@ spec:
             mountPath: {{ $crowdsecConfig }}/config.yaml.local
             subPath: config.yaml.local
           {{- end }}
+          {{- if index .Values.config "feature.yaml" }}
+          - name: crowdsec-feature-volume
+            mountPath: {{ $crowdsecConfig }}/feature.yaml
+            subPath: feature.yaml
+          {{- end }}
 
       terminationGracePeriodSeconds: 30
       volumes:
@@ -329,6 +334,11 @@ spec:
       - name: crowdsec-agent-config-local-volume
         configMap:
           name: crowdsec-agent-config-local
+      {{- end }}
+      {{- if index .Values.config "feature.yaml" }}
+      - name: crowdsec-feature-volume
+        configMap:
+          name: crowdsec-feature
       {{- end }}
       {{- if .Values.agent.extraVolumes }}
       {{ toYaml .Values.agent.extraVolumes | nindent 6 }}

--- a/charts/crowdsec/templates/agent-deployment.yaml
+++ b/charts/crowdsec/templates/agent-deployment.yaml
@@ -53,7 +53,7 @@ spec:
       initContainers:
       {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}
       - name: wait-for-lapi-and-register
-        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ['sh', '-c', 'until nc "$LAPI_HOST" "$LAPI_PORT" -z; do echo waiting for lapi to start; sleep 5; done; ln -s /staging/etc/crowdsec /etc/crowdsec && cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN" && cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml']
       {{- else }}
@@ -96,7 +96,7 @@ spec:
       {{- end }}
       containers:
       - name: crowdsec-agent
-        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
     {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}
       {{- if .Values.agent.persistentVolume.config.enabled }}

--- a/charts/crowdsec/templates/agent-deployment.yaml
+++ b/charts/crowdsec/templates/agent-deployment.yaml
@@ -251,6 +251,11 @@ spec:
             mountPath: {{ $crowdsecConfig }}/config.yaml.local
             subPath: config.yaml.local
           {{- end }}
+          {{- if index .Values.config "feature.yaml" }}
+          - name: crowdsec-feature-volume
+            mountPath: {{ $crowdsecConfig }}/feature.yaml
+            subPath: feature.yaml
+          {{- end }}
 
       terminationGracePeriodSeconds: 30
       volumes:
@@ -332,6 +337,11 @@ spec:
       - name: crowdsec-agent-config-local-volume
         configMap:
           name: crowdsec-agent-config-local
+      {{- end }}
+      {{- if index .Values.config "feature.yaml" }}
+      - name: crowdsec-feature-volume
+        configMap:
+          name: crowdsec-feature
       {{- end }}
       {{- if .Values.agent.extraVolumes }}
       {{ toYaml .Values.agent.extraVolumes | nindent 6 }}

--- a/charts/crowdsec/templates/appsec-deployment.yaml
+++ b/charts/crowdsec/templates/appsec-deployment.yaml
@@ -53,7 +53,7 @@ spec:
       initContainers:
       {{- if or (not .Values.tls.enabled) (not .Values.tls.appsec.tlsClientAuth) }}
       - name: wait-for-lapi-and-register
-        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ['sh', '-c', 'until nc "$LAPI_HOST" "$LAPI_PORT" -z; do echo waiting for lapi to start; sleep 5; done; ln -s /staging/etc/crowdsec /etc/crowdsec && cscli lapi register --machine "$USERNAME" -u "$LAPI_URL" --token "$REGISTRATION_TOKEN" && cp /etc/crowdsec/local_api_credentials.yaml /tmp_config/local_api_credentials.yaml']
       {{- else }}
@@ -110,7 +110,7 @@ spec:
       {{- end }}
       containers:
       - name: crowdsec-appsec
-        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.appsec.tlsClientAuth) }}
         command: ['sh', '-c', 'cp /tmp_config/local_api_credentials.yaml /staging/etc/crowdsec/local_api_credentials.yaml && ./docker_start.sh']

--- a/charts/crowdsec/templates/capi-register-job.yaml
+++ b/charts/crowdsec/templates/capi-register-job.yaml
@@ -52,7 +52,7 @@ spec:
               mountPath: /kubectl-bin
       containers:
         - name: capi-register
-          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
+          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ include "jobsImageTagSuffix" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: kubectl-bin

--- a/charts/crowdsec/templates/capi-register-job.yaml
+++ b/charts/crowdsec/templates/capi-register-job.yaml
@@ -52,7 +52,7 @@ spec:
               mountPath: /kubectl-bin
       containers:
         - name: capi-register
-          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: kubectl-bin

--- a/charts/crowdsec/templates/cscli-lapi-register-job.yaml
+++ b/charts/crowdsec/templates/cscli-lapi-register-job.yaml
@@ -51,7 +51,7 @@ spec:
               mountPath: /kubectl-bin
       containers:
         - name: lapi-cscli-register
-          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: kubectl-bin

--- a/charts/crowdsec/templates/cscli-lapi-register-job.yaml
+++ b/charts/crowdsec/templates/cscli-lapi-register-job.yaml
@@ -51,7 +51,7 @@ spec:
               mountPath: /kubectl-bin
       containers:
         - name: lapi-cscli-register
-          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
+          image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ include "jobsImageTagSuffix" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: kubectl-bin

--- a/charts/crowdsec/templates/feature-configmap.yaml
+++ b/charts/crowdsec/templates/feature-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if index .Values.config "feature.yaml" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: crowdsec-feature
+data:
+  feature.yaml: |
+{{ printf "%+v" (index .Values.config "feature.yaml") | indent 4 }}
+{{- end }}

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -56,7 +56,7 @@ spec:
       {{- end }}
       containers:
       - name: crowdsec-lapi
-        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository | default "crowdsecurity/crowdsec" }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.tagSuffix }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.lapi.envFrom }}
         envFrom:

--- a/charts/crowdsec/templates/lapi-deployment.yaml
+++ b/charts/crowdsec/templates/lapi-deployment.yaml
@@ -236,6 +236,11 @@ spec:
             mountPath: {{ $crowdsecConfig }}/config.yaml.local
             subPath: config.yaml.local
           {{ end }}
+          {{ if index .Values.config "feature.yaml" }}
+          - name: crowdsec-feature-volume
+            mountPath: {{ $crowdsecConfig }}/feature.yaml
+            subPath: feature.yaml
+          {{ end }}
           {{- if (include "notificationsIsNotEmpty" .) -}}
           {{ range $fileName, $content := .Values.config.notifications -}}
           {{- if $content }}
@@ -305,6 +310,11 @@ spec:
       - name: crowdsec-config-local-volume
         configMap:
           name: crowdsec-config-local
+      {{- end }}
+      {{ if index .Values.config "feature.yaml" }}
+      - name: crowdsec-feature-volume
+        configMap:
+          name: crowdsec-feature
       {{- end }}
       {{- if (include "notificationsIsNotEmpty" .) -}}
       {{ range $fileName, $content := .Values.config.notifications -}}

--- a/charts/crowdsec/templates/lapi-pdb.yaml
+++ b/charts/crowdsec/templates/lapi-pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.lapi.enabled }}
+{{- if .Values.lapi.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-lapi-pdb
+  labels:
+    k8s-app: {{ .Release.Name }}
+    type: lapi
+spec:
+  selector:
+    matchLabels:
+      k8s-app: {{ .Release.Name }}
+      type: lapi
+  {{- if not (kindIs "invalid" .Values.lapi.podDisruptionBudget.minAvailable) }}
+  minAvailable: {{ .Values.lapi.podDisruptionBudget.minAvailable }}
+  {{- else if not (kindIs "invalid" .Values.lapi.podDisruptionBudget.maxUnavailable) }}
+  maxUnavailable: {{ .Values.lapi.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/crowdsec/values.schema.json
+++ b/charts/crowdsec/values.schema.json
@@ -43,6 +43,9 @@
                 "tag": {
                     "type": "string"
                 },
+                "tagSuffix": {
+                    "type": "string"
+                },
                 "pullPolicy": {
                     "type": "string"
                 },

--- a/charts/crowdsec/values.schema.json
+++ b/charts/crowdsec/values.schema.json
@@ -66,6 +66,14 @@
                         "repository",
                         "pullPolicy"
                     ]
+                },
+                "jobs": {
+                    "type": "object",
+                    "properties": {
+                        "tagSuffix": {
+                            "type": ["string", "null"]
+                        }
+                    }
                 }
             },
             "required": [

--- a/charts/crowdsec/values.schema.json
+++ b/charts/crowdsec/values.schema.json
@@ -224,6 +224,9 @@
                 },
                 "appsec_config.yaml.local": {
                     "type": "string"
+                },
+                "feature.yaml": {
+                    "type": "string"
                 }
             },
             "title": "Config"

--- a/charts/crowdsec/values.schema.json
+++ b/charts/crowdsec/values.schema.json
@@ -174,6 +174,9 @@
                 "podName": {
                     "type": "string"
                 },
+                "containerName": {
+                    "type": "string"
+                },
                 "program": {
                     "type": "string"
                 },

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -168,6 +168,14 @@ config:
   ## @param config.appsec_config.yaml.local This configuration file is merged with appsec pod main configuration file
   appsec_config.yaml.local: ""
 
+  # -- Feature flags configuration (https://docs.crowdsec.net/docs/configuration/feature_flags)
+  # This file is mounted in both lapi and agent pods
+  ## @param config.feature.yaml Feature flags to enable or disable experimental CrowdSec features
+  feature.yaml: ""
+  #   |
+  # - cscli_setup
+  # - re2_grok_support
+
 # @section tls
 tls:
   ## @param tls.enabled  Is tls enabled ?

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -23,6 +23,9 @@ image:
   ## @param image.tag [string] docker image tag (empty defaults to chart AppVersion)
   tag: ""
 
+  ## @param image.tagSuffix [string] Suffix appended to the image tag. E.g. set to "-debian" to use crowdsec:v1.6.0-debian
+  tagSuffix: ""
+
   ## @param image.kubectl.repository [default: alpine/kubectl] [string] kubectl image repository used by registration jobs initContainers
   ## @param image.kubectl.tag [default: latest] [string] kubectl image tag (override to match your cluster version if you encounter issues with registration jobs)
   ## @param image.kubectl.pullPolicy [default: IfNotPresent] [string] kubectl image pull policy (Always, IfNotPresent, Never)

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -520,12 +520,14 @@ agent:
     #   listen_port: 4242
     #   labels:
     #     type: syslog
-  # -- Specify each pod you want to process it logs (namespace, podName and program)
-  ## @param agent.acquisition [array] Pod log acquisition definitions (namespace, podName, program, etc.)
+  # -- Specify each pod you want to process it logs (namespace, podName, optional containerName, and program)
+  ## @param agent.acquisition [array] Pod log acquisition definitions (namespace, podName, optional containerName, program, etc.)
   acquisition: []
     #- namespace: "" #ingress-nginx
     # -- to select pod logs to process
     #  podName: "" #ingress-nginx-controller-*
+    # -- optional container name to restrict acquisition to a single container within matching pods
+    #  containerName: "" #controller
     # -- program name related to specific parser you will use (see https://hub.crowdsec.net/author/crowdsecurity/configurations/docker-logs)
     #  program: "" #nginx
     # -- If set to true, will poll the files using os.Stat instead of using inotify

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -34,6 +34,10 @@ image:
     tag: latest
     pullPolicy: IfNotPresent
 
+  ## @param image.jobs.tagSuffix [string,nullable] Suffix appended to the image tag for registration jobs. When null (default), inherits from image.tagSuffix. Set to "" to use the Alpine-based image when image.tagSuffix is "-debian" (jobs use apk and are incompatible with the Debian image).
+  jobs:
+    tagSuffix: ~
+
 ## @param podAnnotations [object] podAnnotations to be added to pods (string:string map)
 podAnnotations: {}
   # Uncomment the following lines if you use Prometheus Helm Chart rather than Prometheus Operator.

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -450,6 +450,15 @@ lapi:
   # -- If set to true, the credentials used by cscli in the LAPI pod will be stored in a secret. Useful when lapi replicas > 1, as they will be reused in the replicas, and will limit the number of "fake" LPs in the console.
   ## @param lapi.storeLAPICscliCredentialsInSecret [default: false] [object] Store LAPI cscli credentials in a Secret. Useful if LAPI replicas > 1 or to setup LAPI with a persistent volume.
   storeLAPICscliCredentialsInSecret: false
+
+  ## @param lapi.podDisruptionBudget.enabled Enable PodDisruptionBudget for LAPI pods
+  ## @param lapi.podDisruptionBudget.minAvailable [nullable] Minimum number of available LAPI pods during voluntary disruptions. Use either minAvailable or maxUnavailable, not both.
+  ## @param lapi.podDisruptionBudget.maxUnavailable [nullable] Maximum number of unavailable LAPI pods during voluntary disruptions. Use either minAvailable or maxUnavailable, not both.
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: 1
+
 # agent will deploy pod on every node as daemonSet to read wanted pods logs
 ## @section agent
 agent:
@@ -478,6 +487,12 @@ agent:
   ## @param agent.strategy [object] Deployment strategy when `isDeployment` is true
   strategy:
     type: Recreate
+
+  ## @param agent.updateStrategy [object] Update strategy for the agent DaemonSet (when isDeployment is false)
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
 
   # -- add your custom ports here, by default we expose port 6060 for metrics if metrics is enabled
   ## @param agent.ports [array] Custom container ports to expose (default: metrics port 6060 if enabled)


### PR DESCRIPTION
## Summary

- Add `image.tagSuffix` to append a suffix to image tags (for alternative image flavors)
- Add `image.jobs.tagSuffix` to override suffix for registration jobs (keep Alpine compatibility when main image uses `-debian`)
- Add `lapi.podDisruptionBudget` to protect LAPI availability during voluntary disruptions
- Add `agent.updateStrategy` to configure DaemonSet rollout behavior
- Add `config.feature.yaml` to configure CrowdSec feature flags mounted in LAPI and agent pods
- Add optional `agent.acquisition[].containerName` to restrict pod log acquisition to a specific container, while preserving existing wildcard behavior when omitted

## Validation

- `helm lint ./charts/crowdsec/ -f ./charts/crowdsec/ci/crowdsec-values.yaml`
- `helm template` check with `containerName` set: renders `/var/log/containers/<pod>_<namespace>_<container>-*.log`
- `helm template` check without `containerName`: keeps `/var/log/containers/<pod>_<namespace>_*.log`
- Regenerated chart docs with `@bitnami/readme-generator-for-helm`

/kind enhancement
/area configuration