### PR TITLE
fix: replace dashes to prevent flux trying to split the file

### DIFF
--- a/charts/crowdsec/files/docker-start-custom.sh
+++ b/charts/crowdsec/files/docker-start-custom.sh
@@ -37,12 +37,12 @@ if istrue "$CI_TESTING"; then
     echo "githubciXXXXXXXXXXXXXXXXXXXXXXXX" >/etc/machine-id
 fi
 
-#- DEFAULTS -----------------------#
+#= DEFAULTS =======================#
 
 export CONFIG_FILE="${CONFIG_FILE:=/etc/crowdsec/config.yaml}"
 export CUSTOM_HOSTNAME="${CUSTOM_HOSTNAME:=localhost}"
 
-#- HELPER FUNCTIONS ----------------#
+#= HELPER FUNCTIONS ================#
 
 # csv2yaml <string>
 # generate a yaml list from a comma-separated string of values
@@ -158,7 +158,7 @@ difference() {
   done
 }
 
-#-----------------------------------#
+#====================================#
 
 if [ -n "$CERT_FILE" ] || [ -n "$KEY_FILE" ] ; then
     printf '%b' '\033[0;33m'
@@ -219,7 +219,7 @@ if ( isfalse "$USE_TLS" || [ "$CLIENT_CERT_FILE" = "" ] ); then
     fi
 fi
 
-# ----------------
+# ================
 
 conf_set_if "$LOCAL_API_URL" '.url = strenv(LOCAL_API_URL)' "$lapi_credentials_path"
 


### PR DESCRIPTION
Fixes https://github.com/crowdsecurity/helm-charts/issues/342

I think Fluxcd's helm-controller tries to split this as if it's a multidoc yaml file for some reason... Tested and verified the fix on my own cluster running flux-operator 0.44.0, with flux v1.5.2 and helm-controller v1.5.2.

I will raise an issue with flux as well, this doesn't seem like it's supposed to happen