### PR TITLE
Fix rolebinding.yaml

### DIFF
--- a/charts/crowdsec/templates/rolebinding.yaml
+++ b/charts/crowdsec/templates/rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.lapi.enabled }}
+{{- if not (eq (include "IsOnlineAPIDisabled" .) "true") }}
 {{- if or (eq (include "StoreCAPICredentialsInSecret" .) "true") (eq (include "StoreLAPICscliCredentialsInSecret" .) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -21,5 +22,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-configmap-updater-sa
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Currently this fails because the role is missing, when creating the rolebinding. This can happen if "IsOnlineAPIDisabled" evaluates to "true".