### PR TITLE
fix: keep cscli RBAC when online API is disabled

### DIFF
--- a/charts/crowdsec/Chart.yaml
+++ b/charts/crowdsec/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.24.0
+version: 0.24.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crowdsec/templates/role.yaml
+++ b/charts/crowdsec/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.lapi.enabled }}
-{{- if not (eq (include "IsOnlineAPIDisabled" .) "true") }}
+{{- if or (not (eq (include "IsOnlineAPIDisabled" .) "true")) (eq (include "StoreLAPICscliCredentialsInSecret" .) "true") }}
 {{- if or (eq (include "StoreCAPICredentialsInSecret" .) "true") (eq (include "StoreLAPICscliCredentialsInSecret" .) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/crowdsec/templates/rolebinding.yaml
+++ b/charts/crowdsec/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.lapi.enabled }}
-{{- if not (eq (include "IsOnlineAPIDisabled" .) "true") }}
+{{- if or (not (eq (include "IsOnlineAPIDisabled" .) "true")) (eq (include "StoreLAPICscliCredentialsInSecret" .) "true") }}
 {{- if or (eq (include "StoreCAPICredentialsInSecret" .) "true") (eq (include "StoreLAPICscliCredentialsInSecret" .) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Description

## What

Render the `configmap-updater` Role and RoleBinding whenever the LAPI cscli
credentials are stored in a Secret, even when the online API is disabled.

Fixes #319.

## Why

The `lapi-cscli-register-job` is rendered whenever cscli credentials are stored
in a Secret (`StoreLAPICscliCredentialsInSecret`), independently of the online
API setting. It runs under the `*-configmap-updater-sa` ServiceAccount and needs
`get`/`create` permissions on the credentials Secret.

However, #347 gated the Role/RoleBinding behind `not IsOnlineAPIDisabled`. As a
result, with:

```yaml
lapi:
  env:
    - name: DISABLE_ONLINE_API
      value: "true"
```

the register job is still created but its ServiceAccount has no permissions, so
the job fails:

```
error: failed to create secret secrets "<release>-lapi-cscli-credentials" already exists
```

(the secret-existence guard `kubectl get secret ...` is silently denied by RBAC,
so the job falls through to `kubectl create secret` and fails).

## How

`role.yaml` and `rolebinding.yaml` now render when the online API is enabled
**OR** when cscli credentials are stored in a Secret:

```gotemplate
{{- if or (not (eq (include "IsOnlineAPIDisabled" .) "true")) (eq (include "StoreLAPICscliCredentialsInSecret" .) "true") }}
```

The inner `if or (StoreCAPI...) (StoreLAPICscli...)` condition is unchanged, so
the CAPI register job behavior introduced by #347 is preserved (no CAPI RBAC when
the online API is disabled).

## Testing

`helm template` against `ci/crowdsec-values.yaml`:

| Scenario | Expected | Result |
|---|---|---|
| `DISABLE_ONLINE_API=true` + cscli secret | Role + RoleBinding + cscli job rendered | ✅ |
| online API enabled + cscli secret | RBAC + cscli job rendered (no regression) | ✅ |
| online API disabled + creds not in secret | no RBAC | ✅ |

`helm lint ./charts/crowdsec -f ./charts/crowdsec/ci/crowdsec-values.yaml`: passes.

Chart version bumped `0.24.0` → `0.24.1`.
