### PR TITLE
fix: Cannot specify custom ports for AppSec Service resource

### DIFF
--- a/charts/crowdsec/templates/appsec-deployment.yaml
+++ b/charts/crowdsec/templates/appsec-deployment.yaml
@@ -148,6 +148,7 @@ spec:
           - name: INSECURE_SKIP_VERIFY
             value: {{ quote .Values.tls.insecureSkipVerify }}
           {{- end }}
+
         {{- with .Values.appsec.env }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -161,8 +162,7 @@ spec:
             protocol: TCP
           {{- end }}
           {{- range .Values.appsec.acquisitions }}
-            {{- if and (hasKey . "listen_addr") (not startsWith "127.0.0.1" .listen_addr) }}
-          {{- $listen_addr := .listen_addr | default "" }}
+            {{- if and (hasKey . "listen_addr") (not (contains "127.0.0.1:" .listen_addr)) }}
           {{- $url := printf "http://%s/" .listen_addr | urlParse }}
           {{- $port := .listen_addr | replace (printf "%s:" $url.hostname) "" }}
           - name: appsec{{ if ne $port "7422" }}-{{ $port }}{{ end }}
@@ -185,8 +185,6 @@ spec:
         {{ if .Values.appsec.startupProbe }}
         startupProbe:
 {{ toYaml .Values.appsec.startupProbe | indent 10 }}
-        {{ end }}
-
         {{ end }}
 
         securityContext:

--- a/charts/crowdsec/templates/appsec-deployment.yaml
+++ b/charts/crowdsec/templates/appsec-deployment.yaml
@@ -153,14 +153,24 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.appsec.resources | nindent 10 }}
+        {{- if or (len .Values.appsec.acquisitions) (.Values.appsec.metrics.enabled) }}
         ports:
-          - name: appsec
-            containerPort: 7422
-            protocol: TCP
           {{- if .Values.appsec.metrics.enabled }}
           - name: metrics
             containerPort: 6060
             protocol: TCP
+          {{- end }}
+          {{- range .Values.appsec.acquisitions }}
+            {{- if and (hasKey . "listen_addr") (not startsWith "127.0.0.1" .listen_addr) }}
+          {{- $listen_addr := .listen_addr | default "" }}
+          {{- $url := printf "http://%s/" .listen_addr | urlParse }}
+          {{- $port := .listen_addr | replace (printf "%s:" $url.hostname) "" }}
+          - name: appsec{{ if ne $port "7422" }}-{{ $port }}{{ end }}
+            containerPort: {{ $port }}
+            protocol: TCP
+            {{- end }}
+          {{- end }}
+        {{- end }}
 
         {{/* Probes depend on the metrics port, there is no other service on the log processor */}}
 

--- a/charts/crowdsec/templates/appsec-service.yaml
+++ b/charts/crowdsec/templates/appsec-service.yaml
@@ -36,8 +36,7 @@ spec:
       name: metrics
     {{- end }}
     {{- range .Values.appsec.acquisitions }}
-      {{- if and (hasKey . "listen_addr") (not startsWith "127.0.0.1" .listen_addr) }}
-    {{- $listen_addr := .listen_addr | default "" }}
+      {{- if and (hasKey . "listen_addr") (not (contains "127.0.0.1:" .listen_addr)) }}
     {{- $url := printf "http://%s/" .listen_addr | urlParse }}
     {{- $port := .listen_addr | replace (printf "%s:" $url.hostname) "" }}
     - port: {{ $port }}

--- a/charts/crowdsec/templates/appsec-service.yaml
+++ b/charts/crowdsec/templates/appsec-service.yaml
@@ -27,15 +27,26 @@ spec:
   {{- if or (eq .Values.appsec.service.type "LoadBalancer") (eq .Values.appsec.service.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.appsec.service.externalTrafficPolicy | quote }}
   {{- end }}
+  {{- if or (len .Values.appsec.acquisitions) (.Values.appsec.metrics.enabled) }}
   ports:
+    {{- if .Values.appsec.metrics.enabled }}
     - port: 6060
       targetPort: 6060
       protocol: TCP
       name: metrics
-    - port: 7422
-      targetPort: 7422
+    {{- end }}
+    {{- range .Values.appsec.acquisitions }}
+      {{- if and (hasKey . "listen_addr") (not startsWith "127.0.0.1" .listen_addr) }}
+    {{- $listen_addr := .listen_addr | default "" }}
+    {{- $url := printf "http://%s/" .listen_addr | urlParse }}
+    {{- $port := .listen_addr | replace (printf "%s:" $url.hostname) "" }}
+    - port: {{ $port }}
+      targetPort: {{ $port }}
       protocol: TCP
-      name: appsec
+      name: appsec{{ if ne $port "7422" }}-{{ $port }}{{ end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
   selector:
     k8s-app: {{ .Release.Name }}
     type: appsec


### PR DESCRIPTION
fix: #286

Use appsec acquisitions to detect exposed ports for deployment and service.

/kind enhancement
/area appsec
