### PR TITLE
allow configuring emptyDir volumes

### DIFF
--- a/charts/crowdsec/templates/agent-daemonSet.yaml
+++ b/charts/crowdsec/templates/agent-daemonSet.yaml
@@ -255,7 +255,8 @@ spec:
           name: acquis-configmap
       {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}
       - name: crowdsec-config
-        emptyDir: {}
+        emptyDir:
+          {{- toYaml .Values.agent.crowdsecConfigEmptyDir | nindent 10 }}
       {{- end }}
       {{- if .Values.agent.hostVarLog }}
       - name: varlog

--- a/charts/crowdsec/templates/agent-deployment.yaml
+++ b/charts/crowdsec/templates/agent-deployment.yaml
@@ -256,7 +256,8 @@ spec:
       volumes:
       {{- if or (not .Values.tls.enabled) (not .Values.tls.agent.tlsClientAuth) }}
       - name: crowdsec-config
-        emptyDir: {}
+        emptyDir:
+          {{- toYaml .Values.agent.crowdsecConfigEmptyDir | nindent 10 }}
       {{- end }}
       - name: acquis-config-volume
         configMap:

--- a/charts/crowdsec/templates/appsec-deployment.yaml
+++ b/charts/crowdsec/templates/appsec-deployment.yaml
@@ -242,7 +242,8 @@ spec:
         configMap:
           name: appsec-acquis-config
       - name: crowdsec-config
-        emptyDir: {}
+        emptyDir:
+          {{- toYaml .Values.appsec.crowdsecConfigEmptyDir | nindent 10 }}
       {{- if .Values.appsec.configs -}}
       {{- range $fileName, $content := .Values.appsec.configs }}
       - name: {{ include "crowdsec.volumeName" (printf "crowdsec-appsec-configs-%s" $fileName) }}

--- a/charts/crowdsec/templates/capi-register-job.yaml
+++ b/charts/crowdsec/templates/capi-register-job.yaml
@@ -82,7 +82,8 @@ spec:
                   --from-file=online_api_credentials.yaml=/tmp/online_api_credentials.yaml
       volumes:
         - name: kubectl-bin
-          emptyDir: {}
+          emptyDir:
+            {{- toYaml .Values.lapi.kubectlBinEmptyDir | nindent 12 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/crowdsec/templates/cscli-lapi-register-job.yaml
+++ b/charts/crowdsec/templates/cscli-lapi-register-job.yaml
@@ -81,6 +81,7 @@ spec:
                   --from-file=lapi_cscli_credentials.yaml=/tmp/lapi-cscli-credentials.yaml
       volumes:
         - name: kubectl-bin
-          emptyDir: {}
+          emptyDir:
+            {{- toYaml .Values.lapi.kubectlBinEmptyDir | nindent 12 }}
     {{- end }}
 {{- end }}

--- a/charts/crowdsec/values.yaml
+++ b/charts/crowdsec/values.yaml
@@ -450,6 +450,11 @@ lapi:
   # -- If set to true, the credentials used by cscli in the LAPI pod will be stored in a secret. Useful when lapi replicas > 1, as they will be reused in the replicas, and will limit the number of "fake" LPs in the console.
   ## @param lapi.storeLAPICscliCredentialsInSecret [default: false] [object] Store LAPI cscli credentials in a Secret. Useful if LAPI replicas > 1 or to setup LAPI with a persistent volume.
   storeLAPICscliCredentialsInSecret: false
+
+  # -- Configure the kubectl-bin emptyDir volume of the lapi-cscli-register-job and capi-register-job Jobs
+  ## @param lapi.kubectlBinEmptyDir [object] Configure the kubectl-bin emptyDir volume of the lapi-cscli-register-job and capi-register-job Jobs
+  kubectlBinEmptyDir: {}
+
 # agent will deploy pod on every node as daemonSet to read wanted pods logs
 ## @section agent
 agent:
@@ -557,6 +562,11 @@ agent:
     requests:
       cpu: 500m
       memory: 250Mi
+
+  # -- Configure the crowdsec-config emptyDir volume
+  ## @param agent.crowdsecConfigEmptyDir [object] Configure the crowdsec-config emptyDir volume
+  crowdsecConfigEmptyDir: {}
+
   # -- Enable persistent volumes
   persistentVolume:
     # -- Persistent volume for config folder. Stores local config (parsers, scenarios etc.)
@@ -826,6 +836,9 @@ appsec:
   # -- extraInitContainers for appsec pods
   ## @param appsec.extraInitContainers [array] Extra init containers for AppSec pods
   extraInitContainers: []
+  # -- Configure the crowdsec-config emptyDir volume
+  ## @param appsec.crowdsecConfigEmptyDir [object] Configure the crowdsec-config emptyDir volume
+  crowdsecConfigEmptyDir: {}
   # -- Extra volumes to be added to appsec pods
   ## @param appsec.extraVolumes [array] Extra volumes for AppSec pods
   extraVolumes: []


### PR DESCRIPTION
We are enforcing sizeLimits on all emptyDir volumes. This PR allows us to configure these for the crowdsec chart.